### PR TITLE
Insert Table of Contents if tag exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This Python package
 * Ordered and unordered lists
 * Code blocks (e.g. Python, JSON, XML)
 * Image references (uploaded as Confluence page attachments)
+* [Table of Contents](https://docs.gitlab.com/ee/user/markdown.html#table-of-contents)
 
 ## Getting started
 


### PR DESCRIPTION
There is https://docs.gitlab.com/ee/user/markdown.html#table-of-contents describing `[[_TOC_]]` or `[TOC]` tag. Let's replace these tags by corresponding Confluence XHTML.