### PR TITLE
Add golang to the list of supported markup languages

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -103,6 +103,7 @@ _languages = [
     "delphi",
     "diff",
     "erlang",
+    "go",
     "groovy",
     "html",
     "java",


### PR DESCRIPTION
Adding one more language to the list: golang

<img width="833" alt="Screenshot 2023-09-27 at 5 38 22 AM" src="https://github.com/hunyadi/md2conf/assets/619921/dc8f3699-8c1a-4242-889b-81ea66509873">
