### PR TITLE
Feature: Use 'Tiny link' instead of space/page link

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -314,7 +314,7 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         components = ParseResult(
             scheme="https",
             netloc=link_metadata.domain,
-            path=f"{link_metadata.base_path}/x/{tiny_link_id}",
+            path=f"{link_metadata.base_path}x/{tiny_link_id}",
             params="",
             query="",
             fragment=relative_url.fragment,

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -310,10 +310,11 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         )
         self.links.append(url)
 
+        tiny_link_id: str = page_id_to_tiny_link(int(link_metadata.page_id))
         components = ParseResult(
             scheme="https",
             netloc=link_metadata.domain,
-            path=f"{link_metadata.base_path}/x/{page_id_to_tiny_link(link_metadata.page_id)}",
+            path=f"{link_metadata.base_path}/x/{tiny_link_id}",
             params="",
             query="",
             fragment=relative_url.fragment,


### PR DESCRIPTION
Hello,

The generated links do not work for my Confluence (I work on a self-hosted version): The _confluence/space/ID/page/PAGE_ID_ returns a 404... Looking into Confluence's docs, there is a way to [generate "Tiny links" based on a page id](https://confluence.atlassian.com/confkb/how-to-programmatically-generate-the-tiny-link-of-a-confluence-page-956713432.html).

This PR is a proposal that implements this conversion, so that generated links are tiny links - _which I guess should work in all cases._

By the way, great lib !