### PR TITLE
Add support for creating new pages in Confluence

### DIFF
--- a/md2conf/__main__.py
+++ b/md2conf/__main__.py
@@ -59,6 +59,11 @@ parser.add_argument(
     help="Use this option to set the log verbosity.",
 )
 parser.add_argument(
+    "-r",
+    dest="root_page",
+    help="Root Confluence page to create new pages. If omitted, will raise exception when creating new pages.",
+)
+parser.add_argument(
     "--generated-by",
     default="This page has been generated with a tool.",
     help="Add prompt to pages (default: 'This page has been generated with a tool.').",
@@ -94,6 +99,7 @@ try:
             ConfluenceDocumentOptions(
                 ignore_invalid_url=args.ignore_invalid_url,
                 generated_by=args.generated_by,
+                root_page_id=args.root_page
             ),
         ).synchronize(args.mdpath)
 except requests.exceptions.HTTPError as err:

--- a/md2conf/application.py
+++ b/md2conf/application.py
@@ -2,7 +2,7 @@ import logging
 import os.path
 from typing import Dict
 
-from .api import ConfluenceSession
+from .api import ConfluenceSession, ConfluencePage
 from .converter import (
     ConfluenceDocument,
     ConfluenceDocumentOptions,
@@ -38,7 +38,11 @@ class Application:
     def synchronize_page(self, page_path: str) -> None:
         "Synchronizes a single Markdown page with Confluence."
 
-        self._synchronize_page(page_path, dict())
+        file_name = os.path.basename(page_path)
+        file_name_without_extension = os.path.splitext(file_name)[0]
+
+        metadata = self._get_or_create_page_metadata(os.path.abspath(page_path), file_name_without_extension)
+        self._synchronize_page(page_path, {page_path: metadata})
 
     def synchronize_directory(self, dir: str) -> None:
         "Synchronizes a directory of Markdown pages with Confluence."
@@ -50,24 +54,13 @@ class Application:
         for root, directories, files in os.walk(dir):
             for file_name in files:
                 # check the file extension
-                _, file_extension = os.path.splitext(file_name)
+                file_name_without_extension, file_extension = os.path.splitext(file_name)
                 if file_extension.lower() != ".md":
                     continue
 
-                # parse file
                 absolute_path = os.path.join(os.path.abspath(root), file_name)
-                with open(absolute_path, "r") as f:
-                    document = f.read()
+                metadata = self._get_or_create_page_metadata(absolute_path, file_name_without_extension)
 
-                id, document = extract_page_id(document)
-                confluence_page = self.api.get_page(id.page_id)
-                metadata = ConfluencePageMetadata(
-                    domain=self.api.domain,
-                    base_path=self.api.base_path,
-                    page_id=id.page_id,
-                    space_key=id.space_key or self.api.space_key,
-                    title=confluence_page.title or "",
-                )
                 LOGGER.debug(f"indexed {absolute_path} with metadata: {metadata}")
                 page_metadata[absolute_path] = metadata
 
@@ -76,6 +69,49 @@ class Application:
         # Step 2: Convert each page
         for page_path in page_metadata.keys():
             self._synchronize_page(page_path, page_metadata)
+
+    def _get_or_create_page_metadata(self, absolute_path: str, title: str) -> ConfluencePageMetadata:
+        # parse file
+        with open(absolute_path, "r") as f:
+            document = f.read()
+
+        id, document = extract_page_id(document)
+
+        should_update_file = False
+        if id.page_id is None:
+            confluence_page = self._get_or_create_page(title)
+            should_update_file = True
+
+            if confluence_page is None:
+                raise RuntimeError(
+                    "Markdown document has no Confluence page ID and no root page ID was provided."
+                )
+        else:
+            confluence_page = self.api.get_page(id.page_id)
+
+        if should_update_file:
+            self._write_page_id(absolute_path, document, confluence_page.id)
+
+        return ConfluencePageMetadata(
+            domain=self.api.domain,
+            base_path=self.api.base_path,
+            page_id=confluence_page.id,
+            space_key=id.space_key or self.api.space_key,
+            title=confluence_page.title or "",
+        )
+
+    def _get_or_create_page(self, title) -> ConfluencePage:
+        page_found, page_id = self.api.page_exists(title)
+
+        confluence_page = None
+        if page_found:
+            LOGGER.debug(f"get page {page_id}")
+            confluence_page = self.api.get_page(page_id)
+        elif self.options.root_page_id is not None:
+            LOGGER.debug(f"create page with title '{title}'")
+            confluence_page = self.api.create_page(self.options.root_page_id, title, "")
+
+        return confluence_page
 
     def _synchronize_page(
         self,
@@ -102,3 +138,9 @@ class Application:
         content = document.xhtml()
         LOGGER.debug(f"generated Confluence Storage Format document:\n{content}")
         self.api.update_page(document.id.page_id, content)
+
+    def _write_page_id(self, path, document, page_id) -> None:
+        string = f'<!-- confluence-page-id: {page_id} -->\n'
+
+        with open(path, 'w') as file:
+            file.write(string + document)

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -493,10 +493,6 @@ class ConfluenceQualifiedID:
 
 def extract_page_id(string: str) -> Tuple[ConfluenceQualifiedID, str]:
     page_id, string = extract_value(r"<!--\s+confluence-page-id:\s*(\d+)\s+-->", string)
-    if page_id is None:
-        raise DocumentError(
-            "Markdown document has no Confluence page ID associated with it"
-        )
 
     # extract Confluence space key
     space_key, string = extract_value(
@@ -518,6 +514,7 @@ class ConfluenceDocumentOptions:
 
     ignore_invalid_url: bool = False
     generated_by: Optional[str] = "This page has been generated with a tool."
+    root_page_id: Optional[str] = None
 
 
 class ConfluenceDocument:


### PR DESCRIPTION
Added support for automatically creating new pages in Confluence when the processed Markdown file lacks an appropriate Page Id. When such files are found, the file name is assumed to be the page title. The system then tries to retrieve a page with this title from Confluence. If the page exists, the page id is written to the file. If the page is not found, a new page is created using the root page specified in the command line arguments, and the page id is written to the file.