### PR TITLE
Visit children before transforming nodes (post-order DFS)

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -197,11 +197,10 @@ class NodeVisitor:
 
         for index in range(len(node)):
             source = node[index]
+            self.visit(source)
             target = self.transform(source)
             if target is not None:
                 node[index] = target
-            else:
-                self.visit(source)
 
     def transform(self, child: ET._Element) -> Optional[ET._Element]:
         pass


### PR DESCRIPTION
I noticed links were not working inside admonitions.  This is because we never visit them in the node visitor.  I think it should be changed from pre-order depth first search to post-order depth first search.  This is just something for you to consider, I don't know the full ramifications of this change without more testing.  With the change, I see links inside admonitions are working, but I don't know if it broke something else.