### PR TITLE
Use a different URL for links

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -280,7 +280,6 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
             else:
                 raise DocumentError(msg)
 
-        relative_path = os.path.relpath(absolute_path, self.base_path)
         relative_path = os.path.splitext(os.path.relpath(absolute_path, self.base_path))[0]
 
         link_metadata = self.page_metadata.get(absolute_path)

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -301,7 +301,6 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         components = ParseResult(
             scheme="https",
             netloc=link_metadata.domain,
-            path=f"{link_metadata.base_path}spaces/{link_metadata.space_key}/pages/{link_metadata.page_id}/{link_metadata.title}",
             path=os.path.join(link_metadata.base_path, "display", link_metadata.space_key, relative_path),
             params="",
             query="",

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -281,6 +281,7 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
                 raise DocumentError(msg)
 
         relative_path = os.path.relpath(absolute_path, self.base_path)
+        relative_path = os.path.splitext(os.path.relpath(absolute_path, self.base_path))[0]
 
         link_metadata = self.page_metadata.get(absolute_path)
         if link_metadata is None:
@@ -301,6 +302,7 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
             scheme="https",
             netloc=link_metadata.domain,
             path=f"{link_metadata.base_path}spaces/{link_metadata.space_key}/pages/{link_metadata.page_id}/{link_metadata.title}",
+            path=os.path.join(link_metadata.base_path, "display", link_metadata.space_key, relative_path),
             params="",
             query="",
             fragment=relative_url.fragment,


### PR DESCRIPTION
Links were not working for me.  It could just be the Confluence server I have to deal with.  I do not know if it would work universally, so feel free to disregard this change.

I followed [this page](https://confluence.atlassian.com/confkb/the-differences-between-various-url-formats-for-a-confluence-page-278692715.html) to build links that would work for me.

- Made sure suffix (.md) was not in the generated link
- Made the link of the form `https://confluence.example.com/display/SPACEKEY/Page#Fragment`

Maybe this should be a configuration?