### PR TITLE
Add support for directory structures

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -387,9 +387,8 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
             class_name = "note"
         elif "warning" in class_list:
             class_name = "warning"
-
-        if class_name is None:
-            raise DocumentError(f"unsupported admonition label: {class_list}")
+        else:
+            class_name = "info"
 
         for e in elem:
             self.visit(e)


### PR DESCRIPTION
- New: Fix #26: properly handle directory structure
- New: if page name already exists, create a page by appending invisible space in title
- New: use markdown title (# Title) as title for the page
- Fix: don't raise exception when not finding page in get_page_id_by_title
- Fix: Add confluence keys in markdown pages after frontmatter instead of always at the top (fix for mkdocs-material)
- Fix: If admonition type is not known, default to info instead of raising exception