### PR TITLE
Extract test page id to a sep constant,  use Pathlib

### DIFF
--- a/md2conf/__main__.py
+++ b/md2conf/__main__.py
@@ -26,7 +26,7 @@ class Arguments(argparse.Namespace):
     generated_by: Optional[str]
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.prog = os.path.basename(os.path.dirname(__file__))
     parser.add_argument(


### PR DESCRIPTION
Extracted the test page ID to a constant and put it at the top of the file.  This makes it easier to for other devs to work on this tool by modifying the code just in one place

Also,  switched to Path lib from os.path as it is a more modern alternative and it has been a part of Python standard lib for a while.  Probably should do it in the main code as well,  but need to get more familiar with it first