### PR TITLE
More democratic test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 /.env
 /dist
 /*.egg-info
+.envrc

--- a/md2conf/__main__.py
+++ b/md2conf/__main__.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import sys
 import typing
+from pathlib import Path
 from typing import Optional
 
 import requests
@@ -15,7 +16,7 @@ from .properties import ConfluenceProperties
 
 
 class Arguments(argparse.Namespace):
-    mdpath: str
+    mdpath: Path
     domain: str
     path: str
     username: str
@@ -26,7 +27,7 @@ class Arguments(argparse.Namespace):
     generated_by: Optional[str]
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.prog = os.path.basename(os.path.dirname(__file__))
     parser.add_argument(
@@ -95,6 +96,10 @@ def main():
 
     args = Arguments()
     parser.parse_args(namespace=args)
+
+    # NOTE:  If we switch to modern type aware CLI tool like typer
+    #  the following line won't be necessary
+    args.mdpath = Path(args.mdpath)
 
     logging.basicConfig(
         level=getattr(logging, args.loglevel.upper(), logging.INFO),

--- a/md2conf/api.py
+++ b/md2conf/api.py
@@ -1,12 +1,11 @@
 import json
 import logging
 import mimetypes
-import os
-import os.path
 import sys
 import typing
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from types import TracebackType
 from typing import Dict, Generator, List, Optional, Type, Union
 from urllib.parse import urlencode, urlparse, urlunparse
@@ -184,15 +183,16 @@ class ConfluenceSession:
     def upload_attachment(
         self,
         page_id: str,
-        attachment_path: str,
+        attachment_path: Path,
         attachment_name: str,
         comment: Optional[str] = None,
         *,
         space_key: Optional[str] = None,
+        force: bool = False,
     ) -> None:
         content_type = mimetypes.guess_type(attachment_path, strict=True)[0]
 
-        if not os.path.isfile(attachment_path):
+        if not attachment_path.is_file():
             raise ConfluenceError(f"file not found: {attachment_path}")
 
         try:
@@ -200,7 +200,7 @@ class ConfluenceSession:
                 page_id, attachment_name, space_key=space_key
             )
 
-            if attachment.file_size == os.path.getsize(attachment_path):
+            if not force and attachment.file_size ==  attachment_path.stat().st_size:
                 LOGGER.info("Up-to-date attachment: %s", attachment_name)
                 return
 

--- a/md2conf/application.py
+++ b/md2conf/application.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+from pathlib import Path
 from typing import Dict, Optional
 
 from .api import ConfluenceSession
@@ -25,40 +26,43 @@ class Application:
         self.api = api
         self.options = options
 
-    def synchronize(self, path: str) -> None:
+    def synchronize(self, path: Path) -> None:
         "Synchronizes a single Markdown page or a directory of Markdown pages."
 
-        if os.path.isdir(path):
+        if path.is_dir():
             self.synchronize_directory(path)
-        elif os.path.isfile(path):
+        elif path.is_file():
             self.synchronize_page(path)
         else:
             raise ValueError(f"expected: valid file or directory path; got: {path}")
 
-    def synchronize_page(self, page_path: str) -> None:
+    def synchronize_page(self, page_path: Path) -> None:
         "Synchronizes a single Markdown page with Confluence."
 
         self._synchronize_page(page_path, {})
 
-    def synchronize_directory(self, dir: str) -> None:
+    def synchronize_directory(self, local_dir: Path) -> None:
         "Synchronizes a directory of Markdown pages with Confluence."
 
-        page_metadata: Dict[str, ConfluencePageMetadata] = {}
-        LOGGER.info(f"Synchronizing directory: {dir}")
+        page_metadata: Dict[Path, ConfluencePageMetadata] = {}
+        LOGGER.info(f"Synchronizing directory: {local_dir}")
 
         # Step 1: build index of all page metadata
-        for root, directories, files in os.walk(dir):
+        # NOTE: Pathlib.walk() is implemented only in Python 3.12+
+        # so sticking for old os.walk
+        for root, directories, files in os.walk(local_dir):
             for file_name in files:
-                # check the file extension
-                _, file_extension = os.path.splitext(file_name)
-                if file_extension.lower() != ".md":
+                # Reconstitute Path object back
+                docfile = (Path(root) / file_name).absolute()
+
+                # Skip non-markdown files
+                if docfile.suffix.lower() != ".md":
                     continue
+                # check the file extension
+                metadata = self._get_or_create_page(docfile)
 
-                absolute_path = os.path.join(os.path.abspath(root), file_name)
-                metadata = self._get_or_create_page(absolute_path)
-
-                LOGGER.debug(f"indexed {absolute_path} with metadata: {metadata}")
-                page_metadata[absolute_path] = metadata
+                LOGGER.debug(f"indexed {docfile} with metadata: {metadata}")
+                page_metadata[docfile] = metadata
 
         LOGGER.info(f"indexed {len(page_metadata)} pages")
 
@@ -68,10 +72,10 @@ class Application:
 
     def _synchronize_page(
         self,
-        page_path: str,
-        page_metadata: Dict[str, ConfluencePageMetadata],
+        page_path: Path,
+        page_metadata: Dict[Path, ConfluencePageMetadata],
     ) -> None:
-        base_path = os.path.dirname(page_path)
+        base_path = page_path.parent
 
         LOGGER.info(f"Synchronizing page: {page_path}")
         document = ConfluenceDocument(page_path, self.options, page_metadata)
@@ -83,7 +87,7 @@ class Application:
             self._update_document(document, base_path)
 
     def _get_or_create_page(
-        self, absolute_path: str, title: Optional[str] = None
+        self, absolute_path: Path, title: Optional[str] = None
     ) -> ConfluencePageMetadata:
         """
         Creates a new Confluence page if no page is linked in the Markdown document.
@@ -106,7 +110,7 @@ class Application:
 
             # use file name without extension if no title is supplied
             if title is None:
-                title, _ = os.path.splitext(os.path.basename(absolute_path))
+                title = absolute_path.stem
 
             confluence_page = self.api.get_or_create_page(
                 title, self.options.root_page_id
@@ -126,10 +130,10 @@ class Application:
             title=confluence_page.title or "",
         )
 
-    def _update_document(self, document: ConfluenceDocument, base_path: str) -> None:
+    def _update_document(self, document: ConfluenceDocument, base_path: Path) -> None:
         for image in document.images:
             self.api.upload_attachment(
-                document.id.page_id, os.path.join(base_path, image), image, ""
+                document.id.page_id, base_path / image, image, ""
             )
 
         content = document.xhtml()
@@ -138,7 +142,7 @@ class Application:
 
     def _update_markdown(
         self,
-        path: str,
+        path: Path,
         document: str,
         page_id: str,
         space_key: Optional[str],

--- a/md2conf/properties.py
+++ b/md2conf/properties.py
@@ -1,5 +1,4 @@
 import os
-import os.path
 from typing import Optional
 
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,62 @@
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+from md2conf.converter import (
+    ConfluenceDocumentOptions,
+)
+from md2conf.processor import Processor
+from md2conf.properties import ConfluenceProperties
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(funcName)s [%(lineno)d] - %(message)s",
+)
+
+
+class TestProcessor(unittest.TestCase):
+    out_dir: Path
+
+    def setUp(self) -> None:
+        self.maxDiff = 1024
+
+        test_dir = Path(__file__).parent
+        parent_dir = test_dir.parent
+
+        self.out_dir = test_dir / "output"
+        self.sample_dir = parent_dir / "sample"
+        self.out_dir.mkdir(exist_ok=True, parents=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.out_dir)
+
+    def test_process_document(self) -> None:
+        options = ConfluenceDocumentOptions(
+            ignore_invalid_url=False,
+            generated_by="Test Case",
+            root_page_id="None",
+        )
+
+        properties = ConfluenceProperties("example.com", "/wiki/", "bob@the.operator", "NA", "DUMB")
+        Processor(options, properties).process(self.sample_dir / "code.md")
+
+        self.assertTrue((self.sample_dir / "example.csf").exists())
+
+    def test_process_directory(self) -> None:
+        options = ConfluenceDocumentOptions(
+            ignore_invalid_url=True,
+            generated_by="Dumb",
+            root_page_id="Dumb",
+        )
+
+        properties = ConfluenceProperties("example.com", "/wiki/", "bob@the.operator", "NA", "DUMB")
+        Processor(options, properties).process(self.sample_dir)
+
+        self.assertTrue((self.sample_dir / "example.csf").exists())
+        self.assertTrue((self.sample_dir / "sibling.csf").exists())
+        self.assertTrue((self.sample_dir / "code.csf").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ok, now Path lib  is used throughout the code not only in the test,  so no need to do a lot of `str` conversions.

There are still couple of special cases where we do need to convert to `Path` and `str` I left comments for you