### PR TITLE
Fix/use utf8 and ignore empty comments

### DIFF
--- a/md2conf/api.py
+++ b/md2conf/api.py
@@ -177,7 +177,8 @@ class ConfluenceSession:
         extensions = typing.cast(Dict[str, JsonType], result["extensions"])
         media_type = typing.cast(str, extensions["mediaType"])
         file_size = typing.cast(int, extensions["fileSize"])
-        comment = typing.cast(str, extensions["comment"])
+        comment = extensions.get("comment", "")
+        comment = typing.cast(str, comment)
         return ConfluenceAttachment(id, media_type, file_size, comment)
 
     def upload_attachment(

--- a/md2conf/application.py
+++ b/md2conf/application.py
@@ -94,7 +94,7 @@ class Application:
         """
 
         # parse file
-        with open(absolute_path, "r") as f:
+        with open(absolute_path, "r", encoding="utf-8") as f:
             document = f.read()
 
         qualified_id, document = extract_qualified_id(document)
@@ -147,7 +147,7 @@ class Application:
         page_id: str,
         space_key: Optional[str],
     ) -> None:
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             file.write(f"<!-- confluence-page-id: {page_id} -->\n")
             if space_key:
                 file.write(f"<!-- confluence-space-key: {space_key} -->\n")

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -541,7 +541,7 @@ class ConfluenceDocument:
         self.options = options
         path = path.absolute()
 
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             text = f.read()
 
         # extract Confluence page ID

--- a/md2conf/processor.py
+++ b/md2conf/processor.py
@@ -75,7 +75,7 @@ class Processor:
     def _get_page(self, absolute_path: Path) -> ConfluencePageMetadata:
         "Extracts metadata from a Markdown file."
 
-        with open(absolute_path, "r") as f:
+        with open(absolute_path, "r", encoding="utf-8") as f:
             document = f.read()
 
         qualified_id, document = extract_qualified_id(document)


### PR DESCRIPTION
Hello, i had 2 issues:

1) Emojis and umlaute were presented wrong in Confluence.
2) I could not update Confluence pages with attachements, when the attachments had empty comments.