### PR TITLE
Add custom headers and Confluence Web UI page links generation

### DIFF
--- a/md2conf/__main__.py
+++ b/md2conf/__main__.py
@@ -2,8 +2,9 @@ import argparse
 import logging
 import os.path
 import sys
+import typing
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import requests
 
@@ -31,12 +32,21 @@ class Arguments(argparse.Namespace):
 class KwargsAppendAction(argparse.Action):
     """Append key-value pairs to a dictionary"""
 
-    def __call__(self, parser, args, values, option_string=None):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[None, str, Sequence[Any]],
+        option_string: Optional[str] = None,
+    ) -> None:
         try:
-            d = dict(map(lambda x: x.split('='),values))
+            d = dict(map(lambda x: x.split("="), typing.cast(Sequence[str], values)))
         except ValueError:
-            raise argparse.ArgumentError(self, f"Could not parse argument \"{values}\". It should follow the format: k1=v1 k2=v2 ...")
-        setattr(args, self.dest, d)
+            raise argparse.ArgumentError(
+                self,
+                f'Could not parse argument "{values}". It should follow the format: k1=v1 k2=v2 ...',
+            )
+        setattr(namespace, self.dest, d)
 
 
 def main() -> None:
@@ -132,17 +142,19 @@ def main() -> None:
         default=False,
         help="Write XHTML-based Confluence Storage Format files locally without invoking Confluence API.",
     )
-    parser.add_argument("--headers",
-                        nargs='*',
-                        required=False,
-                        action=KwargsAppendAction,
-                        metavar="KEY=VALUE",
-                        help="Apply custom headers to all Confluence API requests.")
+    parser.add_argument(
+        "--headers",
+        nargs="*",
+        required=False,
+        action=KwargsAppendAction,
+        metavar="KEY=VALUE",
+        help="Apply custom headers to all Confluence API requests.",
+    )
     parser.add_argument(
         "--webui-links",
         action="store_true",
         default=False,
-        help="Enable Confluence Web UI links."
+        help="Enable Confluence Web UI links.",
     )
 
     args = Arguments()
@@ -164,7 +176,7 @@ def main() -> None:
         root_page_id=args.root_page,
         render_mermaid=args.render_mermaid,
         diagram_output_format=args.diagram_output_format,
-        web_links=args.webui_links
+        web_links=args.webui_links,
     )
     properties = ConfluenceProperties(
         args.domain, args.path, args.username, args.apikey, args.space, args.headers

--- a/md2conf/api.py
+++ b/md2conf/api.py
@@ -98,6 +98,10 @@ class ConfluenceAPI:
             session.headers.update(
                 {"Authorization": f"Bearer {self.properties.api_key}"}
             )
+
+        if self.properties.headers:
+            session.headers.update(self.properties.headers)
+
         self.session = ConfluenceSession(
             session,
             self.properties.domain,

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -6,7 +6,6 @@ import logging
 import os.path
 import re
 import sys
-import urllib
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -311,7 +310,7 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         heading.text = None
 
     def _transform_link(self, anchor: ET._Element) -> None:
-        url = urllib.parse.unquote(anchor.attrib["href"])
+        url = anchor.attrib["href"]
         if is_absolute_url(url):
             return
 
@@ -359,9 +358,10 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         )
         self.links.append(url)
 
-        page_url = f"{link_metadata.base_path}spaces/{link_metadata.space_key}/pages/{link_metadata.page_id}/{link_metadata.title}" \
-            if not self.options.web_links \
-            else f"{link_metadata.base_path}pages/viewpage.action?pageId={link_metadata.page_id}"
+        if self.options.web_links:
+            page_url = f"{link_metadata.base_path}pages/viewpage.action?pageId={link_metadata.page_id}"
+        else:
+            page_url = f"{link_metadata.base_path}spaces/{link_metadata.space_key}/pages/{link_metadata.page_id}/{link_metadata.title}"
 
         components = ParseResult(
             scheme="https",

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -256,7 +256,7 @@ class ConfluenceConverterOptions:
     heading_anchors: bool = False
     render_mermaid: bool = False
     diagram_output_format: Literal["png", "svg"] = "png"
-    web_links: bool = True
+    web_links: bool = False
 
 
 class ConfluenceStorageFormatConverter(NodeVisitor):

--- a/md2conf/properties.py
+++ b/md2conf/properties.py
@@ -12,6 +12,7 @@ class ConfluenceProperties:
     space_key: str
     user_name: Optional[str]
     api_key: str
+    headers: Optional[dict]
 
     def __init__(
         self,
@@ -20,6 +21,7 @@ class ConfluenceProperties:
         user_name: Optional[str] = None,
         api_key: Optional[str] = None,
         space_key: Optional[str] = None,
+        headers: Optional[dict] = None
     ) -> None:
         opt_domain = domain or os.getenv("CONFLUENCE_DOMAIN")
         opt_base_path = base_path or os.getenv("CONFLUENCE_PATH")
@@ -48,3 +50,4 @@ class ConfluenceProperties:
         self.user_name = opt_user_name
         self.api_key = opt_api_key
         self.space_key = opt_space_key
+        self.headers = headers

--- a/md2conf/properties.py
+++ b/md2conf/properties.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Dict, Optional
 
 
 class ConfluenceError(RuntimeError):
@@ -12,7 +12,7 @@ class ConfluenceProperties:
     space_key: str
     user_name: Optional[str]
     api_key: str
-    headers: Optional[dict]
+    headers: Optional[Dict[str, str]]
 
     def __init__(
         self,
@@ -21,7 +21,7 @@ class ConfluenceProperties:
         user_name: Optional[str] = None,
         api_key: Optional[str] = None,
         space_key: Optional[str] = None,
-        headers: Optional[dict] = None
+        headers: Optional[Dict[str, str]] = None,
     ) -> None:
         opt_domain = domain or os.getenv("CONFLUENCE_DOMAIN")
         opt_base_path = base_path or os.getenv("CONFLUENCE_PATH")


### PR DESCRIPTION
This pull request adds the following features:

- **Custom headers** - an option was added as `--headers` to be applied to all Confluence API requests. This is useful in cases where you need to pass extra headers to make the request work. For instance, Confluence is behind a gateway that needs some specific credentials to let the request go through (e.g. `--headers mySecret=can_not_say another-header=123`).
- **Confluence Web UI links** - an option was added as `--webui-links` that enables the conversion of relative URLs into compatible Confluence Web UI page links. Currently `md2conf` only generates Confluence API links, such as `https://<confluence_domain>/space/<spaceKey>/pages/<id>/<title>`, which are not understood by Confluence Web UI.

Note: I'm not a Python programmer so this might require some tweaks to make it perfect. I didn't add any tests since relative URLs were not being considered in the current tests and the headers would probably only work with an integration test but it would require a Confluence instance in special circumstances as mentioned above.

P.S.: Feel free to edit the code to your liking.