### PR TITLE
CI/CD

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,8 +1,10 @@
 name: Publish Docker image
 
 on:
-  release:
-    types: [published]
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - '*'
 
 jobs:
   publish_docker:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:
-          name: hunyadi/md2conf
+          name: leventehunyadi/md2conf
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: Dockerfile

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,8 +1,10 @@
 name: Publish Python Package
 
 on:
-  release:
-    types: [published]
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - '*'
 
 jobs:
   pypi-publish:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -22,7 +22,7 @@ jobs:
           pip3 install build
       - name: Build package
         run: |
-          python -m build --sdist --wheel
+          python3 -m build --sdist --wheel
       - name: Publish package distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -16,14 +16,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
-          python3 -m pip install --upgrade pip
+          PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --upgrade pip
           pip3 install build
       - name: Build package
         run: |
-          python -m build --wheel --sdist
-      - name: Publish package distributions to PyPI
+          python -m build --sdist --wheel
+      - name: Publish package distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_ID_TOKEN }}


### PR DESCRIPTION
I noticed that your repo doesn't publish releases and you only push tags.

This will fix the CI/CD to run when you push a new tag.