### PR TITLE
feat(mermaid.py): we need to be able to leverage the is_docker functionality with mmdc installed globally

### DIFF
--- a/md2conf/mermaid.py
+++ b/md2conf/mermaid.py
@@ -29,7 +29,12 @@ def get_mmdc() -> str:
     "Path to the Mermaid diagram converter."
 
     if is_docker():
-        return "/home/md2conf/node_modules/.bin/mmdc"
+        # used to workaround known issue:
+        # https://github.com/mermaid-js/mermaid-cli/blob/master/docs/linux-sandbox-issue.md
+        if os.environ.get("MD2CONF_USE_ROOT_MMDC", "false") == "true":
+            return "mmdc"
+        else:
+            return "/home/md2conf/node_modules/.bin/mmdc"
     elif os.name == "nt":
         return "mmdc.cmd"
     else:


### PR DESCRIPTION
Per the issue described here for Ubuntu 23+

https://github.com/mermaid-js/mermaid-cli/blob/master/docs/linux-sandbox-issue.md

We need to add in some puppeteer configs if we want to use this in docker environment like github action runners

The logic already exists in code, but returns an mmdc executable path that will not work in gha.

This adds an envar that can be used to get the is_docker goodness but still use proper mmdc executable.