### PR TITLE
Remove type=global from /spaces api call

### DIFF
--- a/md2conf/api.py
+++ b/md2conf/api.py
@@ -194,7 +194,7 @@ class ConfluenceSession:
             payload = self._invoke(
                 ConfluenceVersion.VERSION_2,
                 "/spaces",
-                {"ids": id, "type": "global", "status": "current"},
+                {"ids": id, "status": "current"},
             )
             payload = typing.cast(dict[str, JsonType], payload)
             results = typing.cast(list[JsonType], payload["results"])
@@ -216,7 +216,7 @@ class ConfluenceSession:
             payload = self._invoke(
                 ConfluenceVersion.VERSION_2,
                 "/spaces",
-                {"keys": key, "type": "global", "status": "current"},
+                {"keys": key, "status": "current"},
             )
             payload = typing.cast(dict[str, JsonType], payload)
             results = typing.cast(list[JsonType], payload["results"])
@@ -261,7 +261,6 @@ class ConfluenceSession:
         comment: Optional[str] = None,
         force: bool = False,
     ) -> None:
-
         if attachment_path is None and raw_data is None:
             raise ConfluenceError("required: `attachment_path` or `raw_data`")
 


### PR DESCRIPTION
**Context**

Passing the `type=global` query param in the `spaces` API call prevents `md2conf` from being used with `knowledge_base` spaces.

**Note**

I did consider allowing the user to pass in the type via a `--space-type` flag with a default to `global` but my Python isn't fantastic. That feels like it would be a significant improvement over this PR but may not be necessary.

**Contributing**

I've read `CONTRIBUTING.md` and ran `check.sh` prior to raising the PR.