### PR TITLE
Add support for configuring Mermaid diagram scale

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -21,7 +21,7 @@ from urllib.parse import ParseResult, quote_plus, urlparse
 
 import lxml.etree as ET
 from strong_typing.core import JsonType
-from strong_typing.deserializer import JsonTypeError
+from strong_typing.exception import JsonTypeError
 
 from . import drawio, mermaid
 from .collection import ConfluencePageCollection
@@ -32,8 +32,9 @@ from .environment import PageError
 from .extra import override, path_relative_to
 from .latex import get_png_dimensions, remove_png_chunks, render_latex
 from .markdown import markdown_to_html
+from .mermaid import MermaidConfigProperties
 from .metadata import ConfluenceSiteMetadata
-from .scanner import ScannedDocument, Scanner
+from .scanner import MermaidScanner, ScannedDocument, Scanner
 from .toc import TableOfContentsBuilder
 from .uri import is_absolute_url, to_uuid_urn
 from .xml import element_to_text
@@ -390,7 +391,6 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         self.embedded_files = {}
         self.site_metadata = site_metadata
         self.page_metadata = page_metadata
-        self.scanner = Scanner()  # Create once, reuse multiple times
 
     def _transform_heading(self, heading: ET._Element) -> None:
         """
@@ -829,14 +829,14 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
             AC_ELEM("plain-text-body", ET.CDATA(content)),
         )
 
-    def _extract_mermaid_scale(self, content: str) -> Optional[float]:
+    def _extract_mermaid_config(self, content: str) -> Optional[MermaidConfigProperties]:
         """Extract scale from Mermaid YAML front matter configuration."""
         try:
-            properties = self.scanner.fetch_mermaid_properties(content)
+            properties = MermaidScanner().read(content)
+            return properties.config
         except JsonTypeError as ex:
             LOGGER.warning("Failed to extract Mermaid properties: %s", ex)
             return None
-        return properties.config.scale
 
     def _transform_external_mermaid(self, absolute_path: Path, attrs: ImageAttributes) -> ET._Element:
         "Emits Confluence Storage Format XHTML for a Mermaid diagram read from an external file."
@@ -848,8 +848,8 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         if self.options.render_mermaid:
             with open(absolute_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            scale = self._extract_mermaid_scale(content)
-            image_data = mermaid.render_diagram(content, self.options.diagram_output_format, scale=scale)
+            config = self._extract_mermaid_config(content)
+            image_data = mermaid.render_diagram(content, self.options.diagram_output_format, config=config)
             image_filename = attachment_name(relative_path.with_suffix(f".{self.options.diagram_output_format}"))
             self.embedded_files[image_filename] = EmbeddedFileData(image_data, attrs.alt)
             return self._create_attached_image(image_filename, attrs)
@@ -862,8 +862,8 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         "Emits Confluence Storage Format XHTML for a Mermaid diagram defined in a fenced code block."
 
         if self.options.render_mermaid:
-            scale = self._extract_mermaid_scale(content)
-            image_data = mermaid.render_diagram(content, self.options.diagram_output_format, scale=scale)
+            config = self._extract_mermaid_config(content)
+            image_data = mermaid.render_diagram(content, self.options.diagram_output_format, config=config)
             image_hash = hashlib.md5(image_data).hexdigest()
             image_filename = attachment_name(f"embedded_{image_hash}.{self.options.diagram_output_format}")
             self.embedded_files[image_filename] = EmbeddedFileData(image_data)

--- a/md2conf/mermaid.py
+++ b/md2conf/mermaid.py
@@ -11,9 +11,21 @@ import os
 import os.path
 import shutil
 import subprocess
-from typing import Literal
+from dataclasses import dataclass
+from typing import Literal, Optional
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class MermaidConfigProperties:
+    """
+    Configuration options for rendering Mermaid diagrams.
+
+    :param scale: Scaling factor for the rendered diagram.
+    """
+
+    scale: Optional[float] = None
 
 
 def is_docker() -> bool:
@@ -44,8 +56,11 @@ def has_mmdc() -> bool:
     return shutil.which(executable) is not None
 
 
-def render_diagram(source: str, output_format: Literal["png", "svg"] = "png", scale: float = None) -> bytes:
+def render_diagram(source: str, output_format: Literal["png", "svg"] = "png", config: Optional[MermaidConfigProperties] = None) -> bytes:
     "Generates a PNG or SVG image from a Mermaid diagram source."
+
+    if config is None:
+        config = MermaidConfigProperties()
 
     cmd = [
         get_mmdc(),
@@ -58,7 +73,7 @@ def render_diagram(source: str, output_format: Literal["png", "svg"] = "png", sc
         "--backgroundColor",
         "transparent",
         "--scale",
-        str(scale) if scale is not None else "2",
+        str(config.scale or 2),
     ]
     root = os.path.dirname(__file__)
     if is_docker():


### PR DESCRIPTION
Leverage mermaid front-matter to drive the '--scale' property of the mermaid CLI.
closes #153