### PR TITLE
fix(converter): Incorrect class panel

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -1034,16 +1034,16 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         if match:
             skip = len(match.group(0))
             alert = match.group(1)
-            if alert == "INFO":
+            if alert == "NOTE":
                 class_name = "info"
             elif alert == "TIP":
-                class_name = "tip"
+                class_name = "success"
             elif alert == "IMPORTANT":
-                class_name = "tip"
+                class_name = "note"
             elif alert == "WARNING":
                 class_name = "warning"
             elif alert == "CAUTION":
-                class_name = "warning"
+                class_name = "error"
             else:
                 raise DocumentError(f"unsupported GitHub alert: {alert}")
 

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -1034,8 +1034,8 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         if match:
             skip = len(match.group(0))
             alert = match.group(1)
-            if alert == "NOTE":
-                class_name = "note"
+            if alert == "INFO":
+                class_name = "info"
             elif alert == "TIP":
                 class_name = "tip"
             elif alert == "IMPORTANT":


### PR DESCRIPTION
## Motivations
The `NOTE` alert doesn't exist on confluence and create a warning panel. This PR updates the alert string from `NOTE` to `INFO`

## Tests

I have updated locally and tried the following:

```shell
> [!INFO]
> testing the rendering

---
> [!TIP]
> testing the rendering

---
> [!IMPORTANT]
> testing the rendering

---
> [!WARNING]
> testing the rendering

---
> [!CAUTION]
> testing the rendering
```

<img width="1082" height="490" alt="image" src="https://github.com/user-attachments/assets/c149cdcf-a7a4-4649-b160-8d3f88088ea4" />
I think there is still an issue with warnings and notes