### PR TITLE
Expose md2conf as a first-class CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Whenever possible, the implementation uses [Confluence REST API v2](https://deve
 pip install markdown-to-confluence
 ```
 
+After installation, invoke the CLI directly:
+
+```sh
+md2conf --help
+```
+
 ### Command-line utilities
 
 **Optional.** Converting `*.drawio` diagrams to PNG or SVG images before uploading to Confluence as attachments requires installing [draw.io](https://www.drawio.com/). (Refer to `--render-drawio`.)
@@ -647,13 +653,13 @@ The attribute `properties` is parsed as a dictionary with keys of type string an
 You can synchronize a (directory of) Markdown file(s) with Confluence using the command-line tool `md2conf`:
 
 ```sh
-$ python3 -m md2conf sample/index.md
+$ md2conf sample/index.md
 ```
 
 Use the `--help` switch to get a full list of supported command-line options:
 
 ```console
-$ python3 -m md2conf --help
+$ md2conf --help
 usage: md2conf mdpath [mdpath ...] [OPTIONS]
 
 positional arguments:

--- a/md2conf/cli.py
+++ b/md2conf/cli.py
@@ -1,0 +1,11 @@
+"""
+Publish Markdown files to Confluence wiki.
+
+Copyright 2022-2026, Levente Hunyadi
+
+:see: https://github.com/hunyadi/md2conf
+"""
+
+from .__main__ import main
+
+__all__ = ["main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ formulas = [
 "Source" = "https://github.com/hunyadi/md2conf"
 
 [project.scripts]
-md2conf = "md2conf.__main__:main"
+md2conf = "md2conf.cli:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -13,7 +13,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
+from md2conf import __main__
 from md2conf.attachment import attachment_name
+from md2conf.cli import main as cli_main
 from md2conf.coalesce import coalesce
 from md2conf.converter import title_to_identifier
 from md2conf.formatting import display_width
@@ -56,6 +58,9 @@ class _C:
 
 class TestUnit(TypedTestCase):
     "Simple unit tests without set-up or tear-down requirements."
+
+    def test_cli_entrypoint(self) -> None:
+        self.assertIs(cli_main, __main__.main)
 
     def test_reflection(self) -> None:
         self.assertCountEqual(get_nested_types([_C]), [_A, _B, _C, _X, _Y, bool, complex, datetime, int, str])

--- a/util/documentation.py
+++ b/util/documentation.py
@@ -58,8 +58,8 @@ def update_console(text: str) -> str:
     "Updates the console output section in `README.md`."
 
     output, count = re.subn(
-        r"^```console\n\$ python3 -m md2conf --help\n.*?^```$",
-        f"```console\n$ python3 -m md2conf --help\n{help_text}```",
+        r"^```console\n\$ md2conf --help\n.*?^```$",
+        f"```console\n$ md2conf --help\n{help_text}```",
         text,
         count=1,
         flags=re.DOTALL | re.MULTILINE,


### PR DESCRIPTION
This change makes the package installable as a direct CLI tool (`md2conf ...`) instead of requiring module-style invocation (`python -m md2conf ...`). It also updates top-level docs to make CLI installation and usage explicit for contributors and end users.

- **CLI entrypoint refactor**
  - Added a dedicated `md2conf.cli` module that re-exports `main`.
  - Switched packaging script target from `md2conf.__main__:main` to `md2conf.cli:main` in `pyproject.toml`.
  - Keeps existing runtime behavior while giving a stable, explicit CLI surface for distribution.

- **Docs: installation + usage clarity**
  - Updated README near the top of the Installation section to show direct CLI invocation after install.
  - Replaced usage examples from `python3 -m md2conf ...` to `md2conf ...` for consistency.

- **Docs generation consistency**
  - Updated `util/documentation.py` so generated/validated README console help blocks now use `md2conf --help`.

- **Focused regression coverage**
  - Added a unit test asserting the CLI entrypoint wiring (`md2conf.cli.main` delegates to the same callable as `md2conf.__main__.main`).

```toml
# pyproject.toml
[project.scripts]
md2conf = "md2conf.cli:main"
```

```sh
pip install markdown-to-confluence
md2conf --help
```

<!-- START COPILOT CODING AGENT TIPS -->
---

