### PR TITLE
Retry requests

### DIFF
--- a/md2conf/api_base.py
+++ b/md2conf/api_base.py
@@ -94,12 +94,7 @@ class ConfluenceSession(ABC):
 
     def __init__(self, session: requests.Session) -> None:
         self._session = session
-        retry_strategy = Retry(
-            total = 3,
-            backoff_factor = 1,
-            status_forcelist = [429],
-            allowed_methods = ["GET", "POST", "PUT", "DELETE"]
-        )
+        retry_strategy = Retry(total=3, backoff_factor=1, status_forcelist=[429], allowed_methods=["GET", "POST", "PUT", "DELETE"])
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
         session.mount("http://", adapter)


### PR DESCRIPTION
In case of rate limits of confluence servers, this change will wait and retry for successful requests.