### PR TITLE
Allow multiple files and directories at top level

### DIFF
--- a/integration_tests/test_api.py
+++ b/integration_tests/test_api.py
@@ -159,9 +159,8 @@ class TestAPI(TypedTestCase):
             source_dir / "index.md",
             source_dir / "doc1.md",
             source_dir / "doc2.md",
-            source_dir / "skip" / "nested" / "index.md",
-            source_dir / "skip" / "nested" / "doc3.md",
-            source_dir / "skip" / "nested" / "deep" / "index.md",
+            source_dir / "nested" / "index.md",
+            source_dir / "nested" / "doc3.md",
         ]
 
         for absolute_path in documents:
@@ -173,8 +172,6 @@ class TestAPI(TypedTestCase):
                     f"# {relative_path}: A sample document",
                     "",
                     "This is a document without an explicitly assigned Confluence page ID or space key.",
-                    "",
-                    "UTF-8 test sequence: árvíztűrő tükörfúrógép.",
                 ]
 
                 frontmatter: list[str] = []

--- a/integration_tests/test_api.py
+++ b/integration_tests/test_api.py
@@ -113,8 +113,7 @@ class TestAPI(TypedTestCase):
             page = api.get_page(self.feature_test_page_id)
             self.assertIsInstance(page, ConfluencePage)
 
-        with open(self.out_dir / "page.html", "w", encoding="utf-8") as f:
-            f.write(sanitize_confluence(page.content))
+        (self.out_dir / "page.html").write_text(sanitize_confluence(page.content), encoding="utf-8")
 
     def test_attachment(self) -> None:
         with ConfluenceAPI() as api:

--- a/integration_tests/test_csf.py
+++ b/integration_tests/test_csf.py
@@ -45,8 +45,7 @@ class TestConfluenceStorageFormat(TypedTestCase):
         with ConfluenceAPI() as api:
             page = api.get_page(self.test_page_id)
 
-        with open(self.test_dir / "example.csf", "w") as f:
-            f.write(content_to_string(page.content))
+        (self.test_dir / "example.csf").write_text(content_to_string(page.content), encoding="utf-8")
 
     def test_labels(self) -> None:
         with ConfluenceAPI() as api:

--- a/md2conf/api.py
+++ b/md2conf/api.py
@@ -51,8 +51,12 @@ class RetryAdapter(HTTPAdapter):
 
     def __init__(self) -> None:
         # spellchecker: disable
-        self._retry_rate_limit = Retry(total=3, allowed_methods=["GET", "POST", "PUT", "DELETE"], status_forcelist=[429], backoff_factor=1)
-        self._retry_eventual_consistency = Retry(total=3, allowed_methods=["GET"], status_forcelist=[404, 429], backoff_factor=1)
+        self._retry_rate_limit = Retry(
+            total=3, allowed_methods=["GET", "POST", "PUT", "DELETE"], status_forcelist=[429], backoff_factor=1, raise_on_redirect=False, raise_on_status=False
+        )
+        self._retry_eventual_consistency = Retry(
+            total=3, allowed_methods=["GET"], status_forcelist=[404, 429], backoff_factor=1, raise_on_redirect=False, raise_on_status=False
+        )
         # spellchecker: enable
         super().__init__()
 

--- a/md2conf/api_base.py
+++ b/md2conf/api_base.py
@@ -30,6 +30,7 @@ from .api_types import (
     ConfluenceStatus,
     ConfluenceVersion,
 )
+from .compatibility import override
 from .environment import ArgumentError, ConfluenceError, PageError
 from .metadata import ConfluenceSiteMetadata
 from .serializer import JsonType, json_to_object, object_to_json_payload
@@ -85,10 +86,308 @@ class ConfluenceUpdateAttachmentRequest:
 
 
 class ConfluenceSession(ABC):
+    @property
+    @abstractmethod
+    def site(self) -> ConfluenceSiteMetadata: ...
+
+    @abstractmethod
+    def close(self) -> None: ...
+
+    @abstractmethod
+    def space_id_to_key(self, id: str) -> str:
+        "Finds the Confluence space key for a space ID."
+        ...
+
+    @abstractmethod
+    def space_key_to_id(self, key: str) -> str:
+        "Finds the Confluence space ID for a space key."
+        ...
+
+    @abstractmethod
+    def get_homepage_id(self, space_id: str) -> str:
+        """
+        Returns the page ID corresponding to the space home page.
+
+        :param space_id: The Confluence space ID.
+        :returns: Page ID of the space homepage.
+        """
+        ...
+
+    @abstractmethod
+    def get_attachments(self, page_id: str) -> list[ConfluenceAttachment]:
+        """
+        Retrieves a list of Confluence page attachments.
+
+        :param page_id: The Confluence page ID.
+        :returns: Confluence attachment information.
+        """
+        ...
+
+    @abstractmethod
+    def get_attachment_by_name(self, page_id: str, filename: str) -> ConfluenceAttachment:
+        """
+        Retrieves a Confluence page attachment by an unprefixed file name.
+
+        :param page_id: The Confluence page ID.
+        :param filename: The attachment filename to search for.
+        :returns: Confluence attachment information.
+        """
+        ...
+
+    @abstractmethod
+    def delete_attachment(self, attachment_id: str) -> None: ...
+
+    @abstractmethod
+    def upload_attachment(
+        self,
+        page_id: str,
+        attachment_name: str,
+        *,
+        attachment_path: Path | None = None,
+        raw_data: bytes | None = None,
+        content_type: str | None = None,
+        comment: str | None = None,
+        force: bool = False,
+    ) -> None:
+        """
+        Uploads a new attachment to a Confluence page.
+
+        :param page_id: Confluence page ID.
+        :param attachment_name: Unprefixed name unique to the page.
+        :param attachment_path: Path to the file to upload as an attachment.
+        :param raw_data: Raw data to upload as an attachment.
+        :param content_type: Attachment MIME type.
+        :param comment: Attachment description.
+        :param force: Overwrite an existing attachment even if there seem to be no changes.
+        """
+
+        ...
+
+    @abstractmethod
+    def get_page_properties_by_title(self, title: str, *, space_id: str | None = None, space_key: str | None = None) -> ConfluencePageProperties:
+        """
+        Looks up a Confluence wiki page ID by title.
+
+        :param title: The page title.
+        :param space_id: The Confluence space ID (unless the default space is to be used). Exclusive with space key.
+        :param space_key: The Confluence space key (unless the default space is to be used). Exclusive with space ID.
+        :returns: Confluence page ID.
+        """
+        ...
+
+    @abstractmethod
+    def get_page(self, page_id: str) -> ConfluencePage:
+        """
+        Retrieves Confluence wiki page details and content.
+
+        Includes retry logic to handle eventual consistency issues when fetching
+        a newly created page that may not be immediately available via the API.
+
+        :param page_id: The Confluence page ID.
+        :returns: Confluence page info and content.
+        """
+        ...
+
+    @abstractmethod
+    def get_page_properties(self, page_id: str) -> ConfluencePageProperties:
+        """
+        Retrieves Confluence wiki page details.
+
+        :param page_id: The Confluence page ID.
+        :returns: Confluence page information.
+        """
+        ...
+
+    def get_page_version(self, page_id: str) -> int:
+        """
+        Retrieves a Confluence wiki page version.
+
+        :param page_id: The Confluence page ID.
+        :returns: Confluence page version.
+        """
+
+        return self.get_page_properties(page_id).version.number
+
+    @abstractmethod
+    def update_page(self, page_id: str, content: str, *, title: str, version: int, message: str) -> None: ...
+    @abstractmethod
+    def create_page(self, *, title: str, content: str, parent_id: str, space_id: str) -> ConfluencePage: ...
+    @abstractmethod
+    def delete_page(self, page_id: str, *, purge: bool = False) -> None: ...
+
+    @abstractmethod
+    def page_exists(self, title: str, *, space_id: str | None = None) -> str | None:
+        """
+        Checks if a Confluence page exists with the given title.
+
+        :param title: Page title. Pages in the same Confluence space must have a unique title.
+        :param space_id: Identifies the Confluence space.
+        :returns: Confluence page ID of a matching page (if found), or `None`.
+        """
+        ...
+
+    def get_or_create_page(self, title: str, parent_id: str) -> ConfluencePage:
+        """
+        Finds a page with the given title, or creates a new page if no such page exists.
+
+        :param title: Page title. Pages in the same Confluence space must have a unique title.
+        :param parent_id: Identifies the parent page for a new child page.
+        :returns: Confluence page info for the found or newly created page.
+        """
+
+        parent_page = self.get_page_properties(parent_id)
+        space_id = parent_page.spaceId
+        page_id = self.page_exists(title, space_id=space_id)
+
+        if page_id is not None:
+            LOGGER.debug("Retrieving existing page: %s", page_id)
+            return self.get_page(page_id)
+        else:
+            LOGGER.debug("Creating new page with title: %s", title)
+            return self.create_page(title=title, content="", parent_id=parent_id, space_id=space_id)
+
+    @abstractmethod
+    def get_labels(self, page_id: str) -> list[ConfluenceIdentifiedLabel]:
+        """
+        Retrieves labels for a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :returns: A list of page labels.
+        """
+        ...
+
+    @abstractmethod
+    def add_labels(self, page_id: str, labels: list[ConfluenceLabel]) -> None:
+        """
+        Adds labels to a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param labels: A list of page labels to add.
+        """
+
+        ...
+
+    @abstractmethod
+    def remove_labels(self, page_id: str, labels: list[ConfluenceLabel]) -> None:
+        """
+        Removes labels from a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param labels: A list of page labels to remove.
+        """
+
+        ...
+
+    @abstractmethod
+    def update_labels(self, page_id: str, labels: list[ConfluenceLabel], *, keep_existing: bool = False) -> None:
+        """
+        Assigns the specified labels to a Confluence page. Existing labels are removed.
+
+        :param page_id: The Confluence page ID.
+        :param labels: A list of page labels to assign.
+        """
+
+        ...
+
+    @abstractmethod
+    def get_content_property_for_page(self, page_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
+        """
+        Retrieves a content property for a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param key: The name of the property to fetch (with case-sensitive match).
+        :returns: The content property value, or `None` if not found.
+        """
+        ...
+
+    @abstractmethod
+    def get_content_properties_for_page(self, page_id: str) -> list[ConfluenceIdentifiedContentProperty]:
+        """
+        Retrieves content properties for a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :returns: A list of content properties.
+        """
+        ...
+
+    @abstractmethod
+    def add_content_property_to_page(self, page_id: str, property: ConfluenceContentProperty) -> ConfluenceIdentifiedContentProperty:
+        """
+        Adds a new content property to a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param property: Content property to add.
+        :returns: The created content property with ID and version.
+        """
+        ...
+
+    @abstractmethod
+    def remove_content_property_from_page(self, page_id: str, property_id: str) -> None:
+        """
+        Removes a content property from a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param property_id: Property ID, which uniquely identifies the property.
+        """
+        ...
+
+    @abstractmethod
+    def update_content_property_for_page(
+        self, page_id: str, property_id: str, version: int, property: ConfluenceContentProperty
+    ) -> ConfluenceIdentifiedContentProperty:
+        """
+        Updates an existing content property associated with a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param property_id: Property ID, which uniquely identifies the property.
+        :param version: Version number to assign.
+        :param property: Content property data to assign.
+        :returns: Updated content property data.
+        """
+        ...
+
+    def update_content_properties_for_page(self, page_id: str, properties: list[ConfluenceContentProperty], *, keep_existing: bool = False) -> None:
+        """
+        Updates content properties associated with a Confluence page.
+
+        :param page_id: The Confluence page ID.
+        :param properties: A list of content property data to update.
+        :param keep_existing: Whether to keep content property data whose key is not included in the list of properties passed as an argument.
+        """
+
+        old_mapping = {p.key: p for p in self.get_content_properties_for_page(page_id)}
+        new_mapping = {p.key: p for p in properties}
+
+        new_props = set(p.key for p in properties)
+        old_props = set(old_mapping.keys())
+
+        add_props = list(new_props - old_props)
+        remove_props = list(old_props - new_props)
+        update_props = list(old_props & new_props)
+
+        if add_props:
+            add_props.sort()
+            for key in add_props:
+                self.add_content_property_to_page(page_id, new_mapping[key])
+        if not keep_existing and remove_props:
+            remove_props.sort()
+            for key in remove_props:
+                self.remove_content_property_from_page(page_id, old_mapping[key].id)
+        if update_props:
+            update_props.sort()
+            for key in update_props:
+                old_prop = old_mapping[key]
+                new_prop = new_mapping[key]
+                if old_prop.value == new_prop.value:
+                    continue
+                self.update_content_property_for_page(page_id, old_prop.id, old_prop.version.number + 1, new_prop)
+
+
+class ConfluenceSessionShared(ConfluenceSession):
     _session: Session
     _api_url: str
 
-    site: ConfluenceSiteMetadata
+    _site: ConfluenceSiteMetadata
 
     def __init__(self, session: Session) -> None:
         self._session = session
@@ -98,8 +397,13 @@ class ConfluenceSession(ABC):
             raise ArgumentError("Confluence domain not specified and cannot be inferred")
         if not base_path:
             raise ArgumentError("Confluence base path not specified and cannot be inferred")
-        self.site = ConfluenceSiteMetadata(domain, base_path, space_key)
+        self._site = ConfluenceSiteMetadata(domain, base_path, space_key)
 
+    @property
+    def site(self) -> ConfluenceSiteMetadata:
+        return self._site
+
+    @override
     def close(self) -> None:
         self._session.close()
         self._session = Session()
@@ -190,16 +494,6 @@ class ConfluenceSession(ABC):
         "Retrieves all results of a REST API paginated result-set."
         ...
 
-    @abstractmethod
-    def space_id_to_key(self, id: str) -> str:
-        "Finds the Confluence space key for a space ID."
-        ...
-
-    @abstractmethod
-    def space_key_to_id(self, key: str) -> str:
-        "Finds the Confluence space ID for a space key."
-        ...
-
     @overload
     def get_space_id(self, *, space_id: str | None = None) -> str | None: ...
 
@@ -230,40 +524,7 @@ class ConfluenceSession(ABC):
         # space ID and key are unset, and no default space is configured
         return None
 
-    @abstractmethod
-    def get_homepage_id(self, space_id: str) -> str:
-        """
-        Returns the page ID corresponding to the space home page.
-
-        :param space_id: The Confluence space ID.
-        :returns: Page ID of the space homepage.
-        """
-        ...
-
-    @abstractmethod
-    def get_attachments(self, page_id: str) -> list[ConfluenceAttachment]:
-        """
-        Retrieves a list of Confluence page attachments.
-
-        :param page_id: The Confluence page ID.
-        :returns: Confluence attachment information.
-        """
-        ...
-
-    @abstractmethod
-    def get_attachment_by_name(self, page_id: str, filename: str) -> ConfluenceAttachment:
-        """
-        Retrieves a Confluence page attachment by an unprefixed file name.
-
-        :param page_id: The Confluence page ID.
-        :param filename: The attachment filename to search for.
-        :returns: Confluence attachment information.
-        """
-        ...
-
-    @abstractmethod
-    def delete_attachment(self, attachment_id: str) -> None: ...
-
+    @override
     def upload_attachment(
         self,
         page_id: str,
@@ -275,18 +536,6 @@ class ConfluenceSession(ABC):
         comment: str | None = None,
         force: bool = False,
     ) -> None:
-        """
-        Uploads a new attachment to a Confluence page.
-
-        :param page_id: Confluence page ID.
-        :param attachment_name: Unprefixed name unique to the page.
-        :param attachment_path: Path to the file to upload as an attachment.
-        :param raw_data: Raw data to upload as an attachment.
-        :param content_type: Attachment MIME type.
-        :param comment: Attachment description.
-        :param force: Overwrite an existing attachment even if there seem to be no changes.
-        """
-
         if attachment_path is None and raw_data is None:
             raise ArgumentError("required: `attachment_path` or `raw_data`")
 
@@ -413,130 +662,19 @@ class ConfluenceSession(ABC):
         LOGGER.info("Updating attachment: %s", attachment_id)
         self._put(ConfluenceVersion.VERSION_1, path, request, None)
 
-    @abstractmethod
-    def get_page_properties_by_title(self, title: str, *, space_id: str | None = None, space_key: str | None = None) -> ConfluencePageProperties:
-        """
-        Looks up a Confluence wiki page ID by title.
-
-        :param title: The page title.
-        :param space_id: The Confluence space ID (unless the default space is to be used). Exclusive with space key.
-        :param space_key: The Confluence space key (unless the default space is to be used). Exclusive with space ID.
-        :returns: Confluence page ID.
-        """
-        ...
-
-    @abstractmethod
-    def get_page(self, page_id: str) -> ConfluencePage:
-        """
-        Retrieves Confluence wiki page details and content.
-
-        Includes retry logic to handle eventual consistency issues when fetching
-        a newly created page that may not be immediately available via the API.
-
-        :param page_id: The Confluence page ID.
-        :returns: Confluence page info and content.
-        """
-        ...
-
-    @abstractmethod
-    def get_page_properties(self, page_id: str) -> ConfluencePageProperties:
-        """
-        Retrieves Confluence wiki page details.
-
-        :param page_id: The Confluence page ID.
-        :returns: Confluence page information.
-        """
-        ...
-
-    def get_page_version(self, page_id: str) -> int:
-        """
-        Retrieves a Confluence wiki page version.
-
-        :param page_id: The Confluence page ID.
-        :returns: Confluence page version.
-        """
-
-        return self.get_page_properties(page_id).version.number
-
-    @abstractmethod
-    def update_page(self, page_id: str, content: str, *, title: str, version: int, message: str) -> None: ...
-    @abstractmethod
-    def create_page(self, *, title: str, content: str, parent_id: str, space_id: str) -> ConfluencePage: ...
-    @abstractmethod
-    def delete_page(self, page_id: str, *, purge: bool = False) -> None: ...
-
-    @abstractmethod
-    def page_exists(self, title: str, *, space_id: str | None = None) -> str | None:
-        """
-        Checks if a Confluence page exists with the given title.
-
-        :param title: Page title. Pages in the same Confluence space must have a unique title.
-        :param space_id: Identifies the Confluence space.
-        :returns: Confluence page ID of a matching page (if found), or `None`.
-        """
-        ...
-
-    def get_or_create_page(self, title: str, parent_id: str) -> ConfluencePage:
-        """
-        Finds a page with the given title, or creates a new page if no such page exists.
-
-        :param title: Page title. Pages in the same Confluence space must have a unique title.
-        :param parent_id: Identifies the parent page for a new child page.
-        :returns: Confluence page info for the found or newly created page.
-        """
-
-        parent_page = self.get_page_properties(parent_id)
-        space_id = parent_page.spaceId
-        page_id = self.page_exists(title, space_id=space_id)
-
-        if page_id is not None:
-            LOGGER.debug("Retrieving existing page: %s", page_id)
-            return self.get_page(page_id)
-        else:
-            LOGGER.debug("Creating new page with title: %s", title)
-            return self.create_page(title=title, content="", parent_id=parent_id, space_id=space_id)
-
-    @abstractmethod
-    def get_labels(self, page_id: str) -> list[ConfluenceIdentifiedLabel]:
-        """
-        Retrieves labels for a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :returns: A list of page labels.
-        """
-        ...
-
+    @override
     def add_labels(self, page_id: str, labels: list[ConfluenceLabel]) -> None:
-        """
-        Adds labels to a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param labels: A list of page labels to add.
-        """
-
         path = f"/content/{page_id}/label"
         self._post(ConfluenceVersion.VERSION_1, path, labels, None)
 
+    @override
     def remove_labels(self, page_id: str, labels: list[ConfluenceLabel]) -> None:
-        """
-        Removes labels from a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param labels: A list of page labels to remove.
-        """
-
         path = f"/content/{page_id}/label"
         for label in labels:
             self._delete(ConfluenceVersion.VERSION_1, path, query={"name": label.name})
 
+    @override
     def update_labels(self, page_id: str, labels: list[ConfluenceLabel], *, keep_existing: bool = False) -> None:
-        """
-        Assigns the specified labels to a Confluence page. Existing labels are removed.
-
-        :param page_id: The Confluence page ID.
-        :param labels: A list of page labels to assign.
-        """
-
         new_labels = set(labels)
         old_labels = set(ConfluenceLabel(name=label.name, prefix=label.prefix) for label in self.get_labels(page_id))
 
@@ -549,96 +687,3 @@ class ConfluenceSession(ABC):
         if not keep_existing and remove_labels:
             remove_labels.sort()
             self.remove_labels(page_id, remove_labels)
-
-    @abstractmethod
-    def get_content_property_for_page(self, page_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
-        """
-        Retrieves a content property for a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param key: The name of the property to fetch (with case-sensitive match).
-        :returns: The content property value, or `None` if not found.
-        """
-        ...
-
-    @abstractmethod
-    def get_content_properties_for_page(self, page_id: str) -> list[ConfluenceIdentifiedContentProperty]:
-        """
-        Retrieves content properties for a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :returns: A list of content properties.
-        """
-        ...
-
-    @abstractmethod
-    def add_content_property_to_page(self, page_id: str, property: ConfluenceContentProperty) -> ConfluenceIdentifiedContentProperty:
-        """
-        Adds a new content property to a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param property: Content property to add.
-        :returns: The created content property with ID and version.
-        """
-        ...
-
-    @abstractmethod
-    def remove_content_property_from_page(self, page_id: str, property_id: str) -> None:
-        """
-        Removes a content property from a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param property_id: Property ID, which uniquely identifies the property.
-        """
-        ...
-
-    @abstractmethod
-    def update_content_property_for_page(
-        self, page_id: str, property_id: str, version: int, property: ConfluenceContentProperty
-    ) -> ConfluenceIdentifiedContentProperty:
-        """
-        Updates an existing content property associated with a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param property_id: Property ID, which uniquely identifies the property.
-        :param version: Version number to assign.
-        :param property: Content property data to assign.
-        :returns: Updated content property data.
-        """
-        ...
-
-    def update_content_properties_for_page(self, page_id: str, properties: list[ConfluenceContentProperty], *, keep_existing: bool = False) -> None:
-        """
-        Updates content properties associated with a Confluence page.
-
-        :param page_id: The Confluence page ID.
-        :param properties: A list of content property data to update.
-        :param keep_existing: Whether to keep content property data whose key is not included in the list of properties passed as an argument.
-        """
-
-        old_mapping = {p.key: p for p in self.get_content_properties_for_page(page_id)}
-        new_mapping = {p.key: p for p in properties}
-
-        new_props = set(p.key for p in properties)
-        old_props = set(old_mapping.keys())
-
-        add_props = list(new_props - old_props)
-        remove_props = list(old_props - new_props)
-        update_props = list(old_props & new_props)
-
-        if add_props:
-            add_props.sort()
-            for key in add_props:
-                self.add_content_property_to_page(page_id, new_mapping[key])
-        if not keep_existing and remove_props:
-            remove_props.sort()
-            for key in remove_props:
-                self.remove_content_property_from_page(page_id, old_mapping[key].id)
-        if update_props:
-            update_props.sort()
-            for key in update_props:
-                old_prop = old_mapping[key]
-                new_prop = new_mapping[key]
-                if old_prop.value == new_prop.value:
-                    continue
-                self.update_content_property_for_page(page_id, old_prop.id, old_prop.version.number + 1, new_prop)

--- a/md2conf/api_v1.py
+++ b/md2conf/api_v1.py
@@ -13,7 +13,7 @@ from typing import TypeVar, cast
 
 from requests import RequestException, Session
 
-from .api_base import ConfluenceSession
+from .api_base import ConfluenceSessionShared
 from .api_types import (
     ConfluenceAttachment,
     ConfluenceContentProperty,
@@ -111,7 +111,7 @@ class ConfluenceCreatePageRequestV1:
     ancestors: list[ConfluencePageRef]
 
 
-class ConfluenceSessionV1(ConfluenceSession):
+class ConfluenceSessionV1(ConfluenceSessionShared):
     """
     Represents an active connection to a Confluence server.
 

--- a/md2conf/api_v2.py
+++ b/md2conf/api_v2.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 from requests import HTTPError, RequestException, Session
 
-from .api_base import ConfluenceSession
+from .api_base import ConfluenceSessionShared
 from .api_types import (
     ConfluenceAttachment,
     ConfluenceContentProperty,
@@ -55,7 +55,7 @@ class ConfluenceUpdatePageRequest:
     version: ConfluenceContentVersion
 
 
-class ConfluenceSessionV2(ConfluenceSession):
+class ConfluenceSessionV2(ConfluenceSessionShared):
     """
     Represents an active connection to a Confluence server.
     """

--- a/md2conf/drawio/render.py
+++ b/md2conf/drawio/render.py
@@ -9,7 +9,6 @@ Copyright 2022-2026, Levente Hunyadi
 import base64
 import logging
 import os
-import shutil
 import subprocess
 import tempfile
 import typing
@@ -19,6 +18,8 @@ from struct import unpack
 from urllib.parse import unquote_to_bytes
 
 import lxml.etree as ET
+
+from md2conf.external import cached_which
 
 ElementType = ET._Element  # pyright: ignore [reportPrivateUsage]
 
@@ -223,11 +224,9 @@ def extract_diagram(path: Path) -> bytes:
     """
 
     if path.name.endswith(".drawio.png"):
-        with open(path, "rb") as png_file:
-            root = extract_xml_from_png(png_file.read())
+        root = extract_xml_from_png(path.read_bytes())
     elif path.name.endswith(".drawio.svg"):
-        with open(path, "rb") as svg_file:
-            root = extract_xml_from_svg(svg_file.read())
+        root = extract_xml_from_svg(path.read_bytes())
     else:
         raise DrawioError(f"unrecognized file type for {path.name}")
 
@@ -237,7 +236,7 @@ def extract_diagram(path: Path) -> bytes:
 def render_diagram(source: Path, output_format: typing.Literal["png", "svg"] = "png") -> bytes:
     "Generates a PNG or SVG image from a draw.io diagram source."
 
-    executable = shutil.which("draw.io")
+    executable = cached_which("draw.io")
     if executable is None:
         raise DrawioError("draw.io executable not found")
 

--- a/md2conf/external.py
+++ b/md2conf/external.py
@@ -8,10 +8,24 @@ Copyright 2022-2026, Levente Hunyadi
 
 import logging
 import re
+import shutil
 import subprocess
+from functools import lru_cache
 from typing import Sequence
 
 LOGGER = logging.getLogger(__name__)
+
+
+@lru_cache
+def cached_which(executable: str) -> str | None:
+    """
+    Cached version of `shutil.which()`.
+
+    :param executable: Name or path of the executable to search for.
+    :returns: Full path to the executable, or `None` if not found.
+    """
+
+    return shutil.which(executable)
 
 
 def execute_subprocess(command: Sequence[str], data: bytes, *, application: str) -> bytes:

--- a/md2conf/local.py
+++ b/md2conf/local.py
@@ -80,11 +80,9 @@ class LocalProcessor(Processor):
         csf_path = self.out_dir / path.relative_to(self.root_dir).with_suffix(".csf")
         csf_dir = csf_path.parent
         os.makedirs(csf_dir, exist_ok=True)
-        with open(csf_path, "w", encoding="utf-8") as f:
-            f.write(content)
+        csf_path.write_text(content, encoding="utf-8")
         for name, file_data in document.embedded_files.items():
-            with open(csf_dir / name, "wb") as f:
-                f.write(file_data.data)
+            (csf_dir / name).write_bytes(file_data.data)
 
 
 class LocalProcessorFactory(ProcessorFactory):

--- a/md2conf/matcher.py
+++ b/md2conf/matcher.py
@@ -121,8 +121,7 @@ class Matcher:
     def __init__(self, options: MatcherOptions, directory: Path) -> None:
         self.options = options
         if os.path.exists(directory / options.source):
-            with open(directory / options.source, "r") as f:
-                rules = f.read().splitlines()
+            rules = (directory / options.source).read_text(encoding="utf-8").splitlines()
             self.rules = [rule for rule in rules if rule and not rule.startswith("#")]
         else:
             self.rules = []

--- a/md2conf/mermaid/extension.py
+++ b/md2conf/mermaid/extension.py
@@ -49,9 +49,7 @@ class MermaidExtension(DiagramExtension):
     def transform_image(self, absolute_path: Path, attrs: ImageAttributes) -> ElementType:
         relative_path = path_relative_to(absolute_path, self.base_dir)
         if self.options.render:
-            with open(absolute_path, "r", encoding="utf-8") as f:
-                content = f.read()
-
+            content = absolute_path.read_text(encoding="utf-8")
             config = self._extract_mermaid_config(content)
             image_data = render_diagram(content, self.generator.options.output_format, config=config)
             return self.generator.transform_attached_data(image_data, attrs, relative_path=relative_path)

--- a/md2conf/mermaid/render.py
+++ b/md2conf/mermaid/render.py
@@ -9,10 +9,9 @@ Copyright 2022-2026, Levente Hunyadi
 import logging
 import os
 import os.path
-import shutil
 from typing import Literal
 
-from md2conf.external import execute_subprocess
+from md2conf.external import cached_which, execute_subprocess
 
 from .config import MermaidConfigProperties
 
@@ -44,7 +43,7 @@ def has_mmdc() -> bool:
     "True if Mermaid diagram converter is available on the OS."
 
     executable = get_mmdc()
-    return shutil.which(executable) is not None
+    return cached_which(executable) is not None
 
 
 def render_diagram(source: str, output_format: Literal["png", "svg"] = "png", config: MermaidConfigProperties | None = None) -> bytes:
@@ -53,8 +52,12 @@ def render_diagram(source: str, output_format: Literal["png", "svg"] = "png", co
     if config is None:
         config = MermaidConfigProperties()
 
+    executable = get_mmdc()
+    if cached_which(executable) is None:
+        raise RuntimeError("Mermaid CLI not found. Install Mermaid CLI from <https://github.com/mermaid-js/mermaid-cli>.")
+
     cmd = [
-        get_mmdc(),
+        executable,
         "--input",
         "-",
         "--output",

--- a/md2conf/plantuml/extension.py
+++ b/md2conf/plantuml/extension.py
@@ -49,11 +49,7 @@ class PlantUMLExtension(DiagramExtension):
     @override
     def transform_image(self, absolute_path: Path, attrs: ImageAttributes) -> ElementType:
         relative_path = path_relative_to(absolute_path, self.base_dir)
-
-        # read PlantUML source
-        with open(absolute_path, "r", encoding="utf-8") as f:
-            content = f.read()
-
+        content = absolute_path.read_text(encoding="utf-8")
         return self._transform_plantuml(content, attrs, relative_path)
 
     @override

--- a/md2conf/plantuml/render.py
+++ b/md2conf/plantuml/render.py
@@ -10,14 +10,13 @@ import base64
 import logging
 import os
 import shlex
-import shutil
 import zlib
 from pathlib import Path
 from typing import Literal
 from urllib.parse import quote
 
 import md2conf
-from md2conf.external import execute_subprocess
+from md2conf.external import cached_which, execute_subprocess
 
 from .config import PlantUMLConfigProperties
 
@@ -69,7 +68,7 @@ def _get_plantuml_command() -> list[str]:
 
     # JAR not found - fail with helpful message
     raise RuntimeError(
-        "PlantUML JAR not found. Download `plantuml.jar` from https://github.com/plantuml/plantuml/releases and set the PLANTUML_JAR environment variable."
+        "PlantUML JAR not found. Download `plantuml.jar` from <https://github.com/plantuml/plantuml/releases> and set the PLANTUML_JAR environment variable."
     )
 
 
@@ -79,7 +78,7 @@ def has_plantuml() -> bool:
     jar_path = _get_plantuml_jar_path()
 
     # Check if we have JAR file and Java is available
-    return jar_path.is_file() and shutil.which("java") is not None
+    return jar_path.is_file() and cached_which("java") is not None
 
 
 def render_diagram(

--- a/md2conf/processor.py
+++ b/md2conf/processor.py
@@ -55,6 +55,11 @@ class DocumentNode:
         self.synchronized = synchronized
         self._children = []
 
+    def __len__(self) -> int:
+        "Number of direct children of this node."
+
+        return len(self._children)
+
     def count(self) -> int:
         "Number of descendants in the sub-tree spanned by this node (excluding the top-level node)."
 
@@ -62,6 +67,13 @@ class DocumentNode:
         for child in self._children:
             c += child.count()
         return c
+
+    def first(self) -> "DocumentNode":
+        "Returns the first child node."
+
+        if not self._children:
+            raise IndexError("no children available")
+        return self._children[0]
 
     def add_child(self, child: "DocumentNode") -> None:
         "Adds a new node to the list of direct children."
@@ -138,10 +150,19 @@ class Processor:
         LOGGER.info("Processing directory: %s", local_dir)
 
         # build index of all Markdown files in directory hierarchy
-        root = self._index_directory(local_dir, None)
+        root = DocumentNode(
+            absolute_path=local_dir / "index.md",  # virtual node; not necessarily a real file
+            page_id=None,
+            space_key=None,
+            title=None,
+            synchronized=False,
+        )
+        self._index_directory(local_dir, root)
         LOGGER.info("Indexed %d document(s)", root.count())
 
-        self._process_items(root)
+        self._verify_items(root)
+        for child in root.children():
+            self._process_items(child)
 
     def process_page(self, path: Path) -> None:
         """
@@ -149,16 +170,12 @@ class Processor:
         """
 
         LOGGER.info("Processing page: %s", path)
-        root = self._index_file(path)
+        node = self._index_file(path)
+        self._process_items(node)
 
-        self._process_items(root)
+    def _verify_items(self, root: DocumentNode) -> None:
+        "Verifies if pages have a unique title to avoid overwrites within synchronized set."
 
-    def _process_items(self, root: DocumentNode) -> None:
-        """
-        Processes a sub-tree rooted at an ancestor node.
-        """
-
-        # verify if pages have a unique title to avoid overwrites within synchronized set
         title_to_path: dict[str, Path] = {}
         duplicates: set[Path] = set()
         for node in root.all():
@@ -173,6 +190,11 @@ class Processor:
             raise PageError(
                 f"expected: each synchronized page to have a unique title but duplicates found in files: {', '.join(str(p) for p in sorted(list(duplicates)))}"
             )
+
+    def _process_items(self, root: DocumentNode) -> None:
+        """
+        Processes a sub-tree rooted at an ancestor node.
+        """
 
         # synchronize directory tree structure with page hierarchy in space (find matching pages in Confluence)
         self._synchronize_tree(root, self.options.root_page)
@@ -208,7 +230,7 @@ class Processor:
         """
         ...
 
-    def _index_directory(self, local_dir: Path, parent: DocumentNode | None) -> DocumentNode:
+    def _index_directory(self, local_dir: Path, parent: DocumentNode) -> None:
         """
         Indexes Markdown files in a directory hierarchy recursively.
         """
@@ -244,8 +266,7 @@ class Processor:
             parent_doc = local_dir / "index.md"
 
             # create a blank page for directory entry
-            with open(parent_doc, "w") as f:
-                print("[[_LISTING_]]", file=f)
+            parent_doc.write_text("[[_LISTING_]]\n", encoding="ascii")
 
         if parent_doc is not None:
             parent_entry = FileEntry(parent_doc.name)
@@ -254,11 +275,8 @@ class Processor:
 
             # promote Markdown document in directory as parent page in Confluence
             node = self._index_file(parent_doc)
-            if parent is not None:
-                parent.add_child(node)
+            parent.add_child(node)
             parent = node
-        elif parent is None:
-            raise ArgumentError(f"root page requires corresponding top-level Markdown document in {local_dir}")
 
         for file in files:
             node = self._index_file(local_dir / Path(file.name))
@@ -266,8 +284,6 @@ class Processor:
 
         for directory in directories:
             self._index_directory(local_dir / Path(directory.name), parent)
-
-        return parent
 
     def _index_file(self, path: Path) -> DocumentNode:
         """
@@ -277,9 +293,7 @@ class Processor:
         LOGGER.info("Indexing file: %s", path)
 
         # extract information from a Markdown document found in a local directory.
-        with open(path, "r", encoding="utf-8") as f:
-            text = f.read()
-
+        text = path.read_text(encoding="utf-8")
         document = Scanner().parse(text)
         props = document.properties
         title = props.title or unique_title(document.text)

--- a/md2conf/publisher.py
+++ b/md2conf/publisher.py
@@ -136,24 +136,23 @@ class SynchronizingProcessor(Processor):
         Updates the original Markdown document to add tags to associate the document with its corresponding Confluence page.
         """
 
-        topmost_id = self._get_topmost_id(tree.page_id, root_id)
+        topmost_id: str | None = None
+        if tree.page_id is not None:
+            # explicitly associated page takes precedence
+            topmost_id = self.api.get_page_properties(tree.page_id).parentId
+        elif root_id is not None:
+            # explicit parameter value
+            topmost_id = root_id
+        elif self.site.space_key is not None:
+            # infer root page from space key
+            topmost_id = self.api.get_homepage_id(self.api.space_key_to_id(self.site.space_key))
+
         if topmost_id is None:
             raise PageError(f"expected: root page ID in options, or explicit page ID in {tree.absolute_path}")
 
         catalog = ParentCatalog(self.api)
         catalog.add_known(topmost_id)
         self._synchronize_subtree(tree, ConfluencePageID(topmost_id), catalog)
-
-    def _get_topmost_id(self, page_id: str | None, root_id: str | None) -> str | None:
-        match (page_id, root_id):
-            case (None, None):
-                if self.site.space_key is not None:
-                    return self.api.get_homepage_id(self.api.space_key_to_id(self.site.space_key))
-            case (None, _):
-                return root_id
-            case _:  # explicit page ID takes precedence
-                return self.api.get_page_properties(str(page_id)).parentId
-        return None
 
     def _synchronize_subtree(self, node: DocumentNode, parent_id: ConfluencePageID, catalog: ParentCatalog) -> None:
         if node.page_id is not None:
@@ -190,7 +189,7 @@ class SynchronizingProcessor(Processor):
             update = True
 
         space_key = self.api.space_id_to_key(page.spaceId)
-        if update and not self.options.skip_update:
+        if update and not self.options.skip_update and node.synchronized:
             self._update_markdown(
                 node.absolute_path,
                 page_id=page.id,
@@ -224,8 +223,7 @@ class SynchronizingProcessor(Processor):
         m = hashlib.md5()
         m.update(object_to_json_payload(self.options.converter))
         m.update(b"\n")
-        with open(path, "rb") as f:
-            m.update(f.read())
+        m.update(path.read_bytes())
         source_digest = m.hexdigest()
 
         # set Confluence title based on Markdown content
@@ -371,10 +369,7 @@ class SynchronizingProcessor(Processor):
         Writes the Confluence page ID and space key at the beginning of the Markdown file.
         """
 
-        with open(path, "r", encoding="utf-8") as file:
-            document = file.read()
-
-        content: list[str] = []
+        document = path.read_text(encoding="utf-8")
 
         # check if the file has frontmatter
         index = 0
@@ -383,6 +378,8 @@ class SynchronizingProcessor(Processor):
         elif document.startswith("<!--\n"):
             index = document.find("\n-->\n", 5) + 4
 
+        content: list[str] = []
+
         if index > 0:
             # insert the Confluence keys after the frontmatter
             content.append(document[:index])
@@ -390,9 +387,7 @@ class SynchronizingProcessor(Processor):
         content.append(f"<!-- confluence-page-id: {page_id} -->")
         content.append(f"<!-- confluence-space-key: {space_key} -->")
         content.append(document[index:])
-
-        with open(path, "w", encoding="utf-8") as file:
-            file.write("\n".join(content))
+        path.write_text("\n".join(content), encoding="utf-8")
 
 
 class SynchronizingProcessorFactory(ProcessorFactory):

--- a/md2conf/scanner.py
+++ b/md2conf/scanner.py
@@ -83,9 +83,7 @@ class Scanner:
         Extracts essential properties from a Markdown document.
         """
 
-        with open(absolute_path, "r", encoding="utf-8") as f:
-            text = f.read()
-
+        text = absolute_path.read_text(encoding="utf-8")
         return self.parse(text)
 
     def parse(self, text: str) -> ScannedDocument:

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,7 +1,9 @@
 *.csf
+embedded_*.mmd
 embedded_*.png
 embedded_*.svg
 figure_*.png
 figure_*.svg
+figure_*.xml
 formula_*.png
 formula_*.svg

--- a/tests/api.py
+++ b/tests/api.py
@@ -35,6 +35,8 @@ from md2conf.metadata import ConfluenceSiteMetadata
 
 LOGGER = logging.getLogger(__name__)
 
+HOMEPAGE_ID = "1000000000"
+
 
 def _require_greater_version(source: int, target: int) -> None:
     if target <= source:
@@ -43,7 +45,7 @@ def _require_greater_version(source: int, target: int) -> None:
 
 class MockConfluenceSession(ConfluenceSession):
     """
-    Emulates Confluence REST API for unit tests.
+    Emulates Confluence REST API calls for unit tests.
 
     Employs an in-memory SQLite database to store attachments, pages and content properties.
     The session is initialized with a single homepage in the root of the space.
@@ -94,7 +96,7 @@ class MockConfluenceSession(ConfluenceSession):
             """
         )
         self._create_page(
-            page_id="HOMEPAGE_ID",
+            page_id=HOMEPAGE_ID,
             title="Home",
             content="<p>This is the root page of the space.</p>",
             parent_id=None,
@@ -265,7 +267,7 @@ class MockConfluenceSession(ConfluenceSession):
     @override
     def get_homepage_id(self, space_id: str) -> str:
         LOGGER.debug("space_id: %s", space_id)
-        return "HOMEPAGE_ID"
+        return HOMEPAGE_ID
 
     @override
     def get_attachments(self, page_id: str) -> list[ConfluenceAttachment]:
@@ -333,7 +335,7 @@ class MockConfluenceSession(ConfluenceSession):
     @override
     def create_page(self, *, title: str, content: str, parent_id: str, space_id: str) -> ConfluencePage:
         LOGGER.debug("parent_id: %s, title: %s", parent_id, title)
-        page_id = f"PAGE_{uuid4().hex[:8].upper()}"
+        page_id = str(uuid4().int % 9_000_000_000 + 1_000_000_000)
         return self._create_page(page_id, title, content, parent_id, space_id)
 
     def _create_page(self, page_id: str, title: str, content: str, parent_id: str | None, space_id: str) -> ConfluencePage:
@@ -447,3 +449,20 @@ class MockConfluenceSession(ConfluenceSession):
             (property_id,),
         ).fetchone()
         return self._row_to_identified_content_property(row)
+
+
+class MockConfluenceAPI:
+    """
+    Emulates Confluence REST API calls for unit tests.
+    """
+
+    _session: MockConfluenceSession
+
+    def __init__(self) -> None:
+        self._session = MockConfluenceSession()
+
+    def __enter__(self) -> MockConfluenceSession:
+        return self._session
+
+    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: object | None) -> None:
+        self._session.close()

--- a/tests/api.py
+++ b/tests/api.py
@@ -1,0 +1,449 @@
+"""
+Publish Markdown files to Confluence wiki.
+
+Copyright 2022-2026, Levente Hunyadi
+
+:see: https://github.com/hunyadi/md2conf
+"""
+
+import datetime
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+from md2conf.api_base import ConfluenceSession
+from md2conf.api_types import (
+    ConfluenceAttachment,
+    ConfluenceContentProperty,
+    ConfluenceContentVersion,
+    ConfluenceIdentifiedContentProperty,
+    ConfluenceIdentifiedLabel,
+    ConfluenceLabel,
+    ConfluencePage,
+    ConfluencePageBody,
+    ConfluencePageParentContentType,
+    ConfluencePageProperties,
+    ConfluencePageStorage,
+    ConfluenceRepresentation,
+    ConfluenceStatus,
+)
+from md2conf.compatibility import override
+from md2conf.environment import ConfluenceError
+from md2conf.metadata import ConfluenceSiteMetadata
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _require_greater_version(source: int, target: int) -> None:
+    if target <= source:
+        raise ConfluenceError(f"expected: version greater than current version {source}; got: {target}")
+
+
+class MockConfluenceSession(ConfluenceSession):
+    """
+    Emulates Confluence REST API for unit tests.
+
+    Employs an in-memory SQLite database to store attachments, pages and content properties.
+    The session is initialized with a single homepage in the root of the space.
+    """
+
+    _site: ConfluenceSiteMetadata
+    _db: sqlite3.Connection
+
+    def __init__(self) -> None:
+        self._site = ConfluenceSiteMetadata(domain="example.atlassian.net", base_path="/wiki/", space_key="SPACE_KEY")
+        self._db = sqlite3.connect(":memory:")
+        self._db.row_factory = sqlite3.Row
+        self._db.execute(
+            """
+            CREATE TABLE attachments (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                createdAt INTEGER NOT NULL,  -- stored as UNIX timestamp
+                pageId TEXT NOT NULL,
+                fileSize INTEGER NOT NULL,
+                version INTEGER NOT NULL,
+                UNIQUE (pageId, title)
+            )
+            """
+        )
+        self._db.execute(
+            """
+            CREATE TABLE pages (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                parentId TEXT,
+                createdAt INTEGER NOT NULL,  -- stored as UNIX timestamp
+                version INTEGER NOT NULL,
+                body TEXT NOT NULL
+            )
+            """
+        )
+        self._db.execute(
+            """
+            CREATE TABLE contentProperties (
+                id TEXT PRIMARY KEY,
+                pageId TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                UNIQUE (pageId, key)
+            )
+            """
+        )
+        self._create_page(
+            page_id="HOMEPAGE_ID",
+            title="Home",
+            content="<p>This is the root page of the space.</p>",
+            parent_id=None,
+            space_id="SPACE_ID",
+        )
+        self._db.commit()
+
+    def _get_page_row(self, page_id: str) -> sqlite3.Row:
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, title, parentId, createdAt, version, body FROM pages WHERE id = ?",
+            (page_id,),
+        ).fetchone()
+        if row is None:
+            raise ConfluenceError(f"page not found with ID: {page_id}")
+        return row
+
+    def _get_content_property_row(self, page_id: str, property_id: str) -> sqlite3.Row:
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, key, value, version FROM contentProperties WHERE id = ? AND pageId = ?",
+            (property_id, page_id),
+        ).fetchone()
+        if row is None:
+            raise ConfluenceError(f"content property not found with ID: {property_id}")
+        return row
+
+    def _get_attachment_row(self, attachment_id: str) -> sqlite3.Row:
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, title, createdAt, pageId, fileSize, version FROM attachments WHERE id = ?",
+            (attachment_id,),
+        ).fetchone()
+        if row is None:
+            raise ConfluenceError(f"attachment not found with ID: {attachment_id}")
+        return row
+
+    def _row_to_attachment(self, row: sqlite3.Row) -> ConfluenceAttachment:
+        return ConfluenceAttachment(
+            id=row["id"],
+            status=ConfluenceStatus.CURRENT,
+            title=row["title"],
+            createdAt=datetime.datetime.fromtimestamp(row["createdAt"], tz=datetime.timezone.utc),
+            pageId=row["pageId"],
+            mediaType="application/octet-stream",
+            mediaTypeDescription=None,
+            comment=None,
+            fileId=row["id"],
+            fileSize=row["fileSize"],
+            webuiLink="",
+            downloadLink="",
+            version=ConfluenceContentVersion(number=row["version"]),
+        )
+
+    def _row_to_page_properties(self, row: sqlite3.Row) -> ConfluencePageProperties:
+        return ConfluencePageProperties(
+            id=row["id"],
+            status=ConfluenceStatus.CURRENT,
+            title=row["title"],
+            spaceId="SPACE_ID",
+            parentId=row["parentId"],
+            parentType=ConfluencePageParentContentType.PAGE,
+            position=0,
+            authorId="AUTHOR_ID",
+            ownerId="OWNER_ID",
+            lastOwnerId=None,
+            createdAt=datetime.datetime.fromtimestamp(row["createdAt"], tz=datetime.timezone.utc),
+            version=ConfluenceContentVersion(number=row["version"]),
+        )
+
+    def _row_to_identified_content_property(self, row: sqlite3.Row) -> ConfluenceIdentifiedContentProperty:
+        return ConfluenceIdentifiedContentProperty(
+            id=row["id"],
+            key=row["key"],
+            value=json.loads(row["value"]),
+            version=ConfluenceContentVersion(number=row["version"]),
+        )
+
+    def _row_to_page(self, row: sqlite3.Row) -> ConfluencePage:
+        props = self._row_to_page_properties(row)
+        return ConfluencePage(
+            id=props.id,
+            status=props.status,
+            title=props.title,
+            spaceId=props.spaceId,
+            parentId=props.parentId,
+            parentType=props.parentType,
+            position=props.position,
+            authorId=props.authorId,
+            ownerId=props.ownerId,
+            lastOwnerId=props.lastOwnerId,
+            createdAt=props.createdAt,
+            version=props.version,
+            body=ConfluencePageBody(
+                storage=ConfluencePageStorage(
+                    representation=ConfluenceRepresentation.STORAGE,
+                    value=row["body"],
+                )
+            ),
+        )
+
+    def get_attachment_count(self) -> int:
+        row: sqlite3.Row = self._db.execute("SELECT COUNT(*) AS count FROM attachments").fetchone()
+        return int(row["count"])
+
+    def get_page_count(self) -> int:
+        row: sqlite3.Row = self._db.execute("SELECT COUNT(*) AS count FROM pages").fetchone()
+        return int(row["count"])
+
+    @property
+    def site(self) -> ConfluenceSiteMetadata:
+        return self._site
+
+    @override
+    def upload_attachment(
+        self,
+        page_id: str,
+        attachment_name: str,
+        *,
+        attachment_path: Path | None = None,
+        raw_data: bytes | None = None,
+        content_type: str | None = None,
+        comment: str | None = None,
+        force: bool = False,
+    ) -> None:
+        if attachment_path is not None:
+            LOGGER.debug("attachment_name: %s, attachment_path: %s", attachment_name, attachment_path)
+            file_size = attachment_path.stat().st_size
+        elif raw_data is not None:
+            LOGGER.debug("attachment_name: %s, raw_data: %d bytes", attachment_name, len(raw_data))
+            file_size = len(raw_data)
+        else:
+            file_size = 0
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, version FROM attachments WHERE pageId = ? AND title = ? LIMIT 1",
+            (page_id, attachment_name),
+        ).fetchone()
+        if row is None:
+            attachment_id = f"ATTACHMENT_{uuid4().hex[:8].upper()}"
+            version = 1
+            self._db.execute(
+                "INSERT INTO attachments (id, title, createdAt, pageId, fileSize, version) VALUES (?, ?, ?, ?, ?, ?)",
+                (attachment_id, attachment_name, int(now.timestamp()), page_id, file_size, version),
+            )
+        else:
+            attachment_id = str(row["id"])
+            version = int(row["version"]) + 1
+            self._db.execute(
+                "UPDATE attachments SET createdAt = ?, fileSize = ?, version = ? WHERE id = ?",
+                (int(now.timestamp()), file_size, version, attachment_id),
+            )
+        self._db.commit()
+        return None
+
+    @override
+    def close(self) -> None:
+        self._db.close()
+
+    @override
+    def space_id_to_key(self, id: str) -> str:
+        LOGGER.debug("space_id: %s", id)
+        return "SPACE_KEY"
+
+    @override
+    def space_key_to_id(self, key: str) -> str:
+        LOGGER.debug("space_key: %s", key)
+        return "SPACE_ID"
+
+    @override
+    def get_homepage_id(self, space_id: str) -> str:
+        LOGGER.debug("space_id: %s", space_id)
+        return "HOMEPAGE_ID"
+
+    @override
+    def get_attachments(self, page_id: str) -> list[ConfluenceAttachment]:
+        LOGGER.debug("page_id: %s", page_id)
+        rows = self._db.execute(
+            "SELECT id, title, createdAt, pageId, fileSize, version FROM attachments WHERE pageId = ? ORDER BY createdAt, title",
+            (page_id,),
+        ).fetchall()
+        return [self._row_to_attachment(row) for row in rows]
+
+    @override
+    def get_attachment_by_name(self, page_id: str, filename: str) -> ConfluenceAttachment:
+        LOGGER.debug("page_id: %s, filename: %s", page_id, filename)
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, title, createdAt, pageId, fileSize, version FROM attachments WHERE pageId = ? AND title = ? LIMIT 1",
+            (page_id, filename),
+        ).fetchone()
+        if row is None:
+            raise ConfluenceError(f"no such attachment on page {page_id}: {filename}")
+        return self._row_to_attachment(row)
+
+    @override
+    def delete_attachment(self, attachment_id: str) -> None:
+        LOGGER.debug("attachment_id: %s", attachment_id)
+        self._get_attachment_row(attachment_id)
+        self._db.execute("DELETE FROM attachments WHERE id = ?", (attachment_id,))
+        self._db.commit()
+        return None
+
+    @override
+    def get_page_properties_by_title(self, title: str, *, space_id: str | None = None, space_key: str | None = None) -> ConfluencePageProperties:
+        LOGGER.debug("title: %s", title)
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, title, parentId, createdAt, version, body FROM pages WHERE title = ? LIMIT 1",
+            (title,),
+        ).fetchone()
+        if row is None:
+            raise ConfluenceError(f"unique page not found with title: {title}")
+        return self._row_to_page_properties(row)
+
+    @override
+    def get_page(self, page_id: str) -> ConfluencePage:
+        LOGGER.debug("page_id: %s", page_id)
+        return self._row_to_page(self._get_page_row(page_id))
+
+    @override
+    def get_page_properties(self, page_id: str) -> ConfluencePageProperties:
+        LOGGER.debug("page_id: %s", page_id)
+        return self._row_to_page_properties(self._get_page_row(page_id))
+
+    @override
+    def update_page(self, page_id: str, content: str, *, title: str, version: int, message: str) -> None:
+        LOGGER.debug("page_id: %s, title: %s", page_id, title)
+        row = self._get_page_row(page_id)
+        _require_greater_version(row["version"], version)
+        cursor = self._db.execute(
+            "UPDATE pages SET title = ?, version = ?, body = ? WHERE id = ?",
+            (title, version, content, page_id),
+        )
+        self._db.commit()
+        if cursor.rowcount == 0:
+            raise ConfluenceError(f"page not found with ID: {page_id}")
+        return None
+
+    @override
+    def create_page(self, *, title: str, content: str, parent_id: str, space_id: str) -> ConfluencePage:
+        LOGGER.debug("parent_id: %s, title: %s", parent_id, title)
+        page_id = f"PAGE_{uuid4().hex[:8].upper()}"
+        return self._create_page(page_id, title, content, parent_id, space_id)
+
+    def _create_page(self, page_id: str, title: str, content: str, parent_id: str | None, space_id: str) -> ConfluencePage:
+        created_at = datetime.datetime.now(datetime.timezone.utc)
+        version = 1
+        self._db.execute(
+            "INSERT INTO pages (id, title, parentId, createdAt, version, body) VALUES (?, ?, ?, ?, ?, ?)",
+            (page_id, title, parent_id, int(created_at.timestamp()), version, content),
+        )
+        self._db.commit()
+        return self.get_page(page_id)
+
+    @override
+    def delete_page(self, page_id: str, *, purge: bool = False) -> None:
+        LOGGER.debug("page_id: %s", page_id)
+        self._db.execute("DELETE FROM pages WHERE id = ?", (page_id,))
+        self._db.commit()
+        return None
+
+    @override
+    def page_exists(self, title: str, *, space_id: str | None = None) -> str | None:
+        LOGGER.debug("title: %s", title)
+        row = self._db.execute("SELECT id FROM pages WHERE title = ? LIMIT 1", (title,)).fetchone()
+        if row is None:
+            return None
+        return str(row["id"])
+
+    @override
+    def get_labels(self, page_id: str) -> list[ConfluenceIdentifiedLabel]:
+        LOGGER.debug("page_id: %s", page_id)
+        return []
+
+    @override
+    def add_labels(self, page_id: str, labels: list[ConfluenceLabel]) -> None:
+        LOGGER.debug("page_id: %s", page_id)
+        return None
+
+    @override
+    def remove_labels(self, page_id: str, labels: list[ConfluenceLabel]) -> None:
+        LOGGER.debug("page_id: %s", page_id)
+        return None
+
+    @override
+    def update_labels(self, page_id: str, labels: list[ConfluenceLabel], *, keep_existing: bool = False) -> None:
+        LOGGER.debug("page_id: %s", page_id)
+        return None
+
+    @override
+    def get_content_property_for_page(self, page_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
+        LOGGER.debug("page_id: %s, property_key: %s", page_id, key)
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, key, value, version FROM contentProperties WHERE pageId = ? AND key = ? LIMIT 1",
+            (page_id, key),
+        ).fetchone()
+        return self._row_to_identified_content_property(row) if row is not None else None
+
+    @override
+    def get_content_properties_for_page(self, page_id: str) -> list[ConfluenceIdentifiedContentProperty]:
+        LOGGER.debug("page_id: %s", page_id)
+        rows = self._db.execute(
+            "SELECT id, key, value, version FROM contentProperties WHERE pageId = ?",
+            (page_id,),
+        ).fetchall()
+        return [self._row_to_identified_content_property(row) for row in rows]
+
+    @override
+    def add_content_property_to_page(self, page_id: str, property: ConfluenceContentProperty) -> ConfluenceIdentifiedContentProperty:
+        LOGGER.debug("page_id: %s, property_key: %s", page_id, property.key)
+        property_id = f"PROP_{uuid4().hex[:8].upper()}"
+        self._db.execute(
+            "INSERT INTO contentProperties (id, pageId, key, value, version) VALUES (?, ?, ?, ?, ?)",
+            (property_id, page_id, property.key, json.dumps(property.value), 1),
+        )
+        self._db.commit()
+        row = self._db.execute(
+            "SELECT id, key, value, version FROM contentProperties WHERE id = ?",
+            (property_id,),
+        ).fetchone()
+        return self._row_to_identified_content_property(row)
+
+    @override
+    def remove_content_property_from_page(self, page_id: str, property_id: str) -> None:
+        LOGGER.debug("page_id: %s, property_id: %s", page_id, property_id)
+        self._db.execute(
+            "DELETE FROM contentProperties WHERE id = ? AND pageId = ?",
+            (property_id, page_id),
+        )
+        self._db.commit()
+        return None
+
+    @override
+    def update_content_property_for_page(
+        self,
+        page_id: str,
+        property_id: str,
+        version: int,
+        property: ConfluenceContentProperty,
+    ) -> ConfluenceIdentifiedContentProperty:
+        LOGGER.debug("page_id: %s, property_id: %s", page_id, property_id)
+        row = self._get_content_property_row(page_id, property_id)
+        _require_greater_version(row["version"], version)
+        cursor = self._db.execute(
+            "UPDATE contentProperties SET key = ?, value = ?, version = ? WHERE id = ? AND pageId = ?",
+            (property.key, json.dumps(property.value), version, property_id, page_id),
+        )
+        self._db.commit()
+        if cursor.rowcount == 0:
+            raise ConfluenceError(f"content property not found with ID: {property_id}")
+        row = self._db.execute(
+            "SELECT id, key, value, version FROM contentProperties WHERE id = ?",
+            (property_id,),
+        ).fetchone()
+        return self._row_to_identified_content_property(row)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -44,8 +44,7 @@ def substitute(root_dir: Path, content: str) -> str:
 
         relative_path = m.group(1)
         absolute_path = root_dir / relative_path
-        with open(absolute_path, "r", encoding="utf-8") as f:
-            file_content = f.read().rstrip()
+        file_content = absolute_path.read_text(encoding="utf-8").rstrip()
         hash = hashlib.md5(file_content.encode()).hexdigest()
         extension = absolute_path.suffix if absolute_path.suffix != ".puml" else ".svg"
         return attachment_name(f"embedded_{hash}{extension}")
@@ -58,8 +57,7 @@ def substitute(root_dir: Path, content: str) -> str:
 
         relative_path = m.group(1)
         absolute_path = root_dir / relative_path
-        with open(absolute_path, "r", encoding="utf-8") as f:
-            file_content = f.read().rstrip()
+        file_content = absolute_path.read_text(encoding="utf-8").rstrip()
         return compress_plantuml_data(file_content)
 
     data_pattern = re.compile(r"DATA\(([^()]+)\)")
@@ -77,8 +75,7 @@ def substitute(root_dir: Path, content: str) -> str:
         if dims is not None:
             width, height = dims
         else:
-            with open(absolute_path, "r", encoding="utf-8") as f:
-                file_content = f.read().rstrip()
+            file_content = absolute_path.read_text(encoding="utf-8").rstrip()
             svg_data = render_diagram(file_content, "svg")
             dims = get_svg_dimensions(svg_data)
             if dims is not None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -64,9 +64,7 @@ class TestDocument(TypedTestCase):
         )
         self.assertListEqual(document.links, [])
         self.assertListEqual(document.images, [])
-
-        with open(self.out_dir / "document.html", "w", encoding="utf-8") as f:
-            f.write(document.xhtml())
+        (self.out_dir / "document.html").write_text(document.xhtml(), encoding="utf-8")
 
     def test_markdown_attachments(self) -> None:
         document_path = self.sample_dir / "attachments.md"
@@ -110,9 +108,7 @@ class TestDocument(TypedTestCase):
                 self.sample_dir / "docs" / "sample.ods",
             ],
         )
-
-        with open(self.out_dir / "document.html", "w", encoding="utf-8") as f:
-            f.write(document.xhtml())
+        (self.out_dir / "document.html").write_text(document.xhtml(), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/test_drawio.py
+++ b/tests/test_drawio.py
@@ -33,22 +33,14 @@ class TestDrawio(TypedTestCase):
 
     def test_xml_from_png(self) -> None:
         image_dir = Path(__file__).parent / "source" / "figure"
-        with open(image_dir / "diagram.drawio", "r") as f:
-            expected = ET.fromstring(f.read())
-
-        with open(image_dir / "diagram.drawio.png", "rb") as f:
-            actual = extract_xml_from_png(f.read())
-
+        expected = ET.fromstring((image_dir / "diagram.drawio").read_text(encoding="utf-8"))
+        actual = extract_xml_from_png((image_dir / "diagram.drawio.png").read_bytes())
         self.assertTrue(is_xml_equal(expected, actual))
 
     def test_xml_from_svg(self) -> None:
         image_dir = Path(__file__).parent / "source" / "figure"
-        with open(image_dir / "diagram.drawio", "r") as f:
-            expected = ET.fromstring(f.read())
-
-        with open(image_dir / "diagram.drawio.svg", "rb") as f:
-            actual = extract_xml_from_svg(f.read())
-
+        expected = ET.fromstring((image_dir / "diagram.drawio").read_text(encoding="utf-8"))
+        actual = extract_xml_from_svg((image_dir / "diagram.drawio.svg").read_bytes())
         self.assertTrue(is_xml_equal(expected, actual))
 
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -90,9 +90,7 @@ class TestProcessor(TypedTestCase):
 
         csf_path = self.out_dir / "index.csf"
         self.assertTrue(csf_path.exists())
-
-        with open(csf_path, "r", encoding="utf-8") as f:
-            content = f.read()
+        content = csf_path.read_text(encoding="utf-8")
 
         generated_by_html = (
             '<ac:structured-macro ac:name="info" ac:schema-version="1">'

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,57 @@
+"""
+Publish Markdown files to Confluence wiki.
+
+Copyright 2022-2026, Levente Hunyadi
+
+:see: https://github.com/hunyadi/md2conf
+"""
+
+import logging
+import unittest
+from pathlib import Path
+
+from md2conf.options import ConfluencePageID, ConverterOptions, ProcessorOptions
+from md2conf.publisher import Publisher
+from tests.api import MockConfluenceSession
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(funcName)s [%(lineno)d] - %(message)s",
+)
+
+
+class TestPublisher(unittest.TestCase):
+    def test_process_sample_directory(self) -> None:
+        parent_dir = Path(__file__).parent.parent
+        sample_dir = parent_dir / "sample"
+        docs_dir = sample_dir / "docs"
+        figure_dir = sample_dir / "figure"
+
+        markdown_count = len(list(sample_dir.rglob("*.md")))
+        docs_count = len(list(docs_dir.rglob("*.*")))
+        figure_count = len(list(figure_dir.rglob("*.*")))
+
+        session = MockConfluenceSession()
+
+        options = ProcessorOptions(
+            root_page=ConfluencePageID(session.get_homepage_id("SPACE_ID")),
+            skip_update=True,
+            converter=ConverterOptions(
+                render_drawio=False,
+                render_mermaid=False,
+                render_plantuml=False,
+                render_latex=False,
+            ),
+        )
+
+        publisher = Publisher(session, options)
+        publisher.process(sample_dir)
+
+        self.assertEqual(session.get_page_count(), markdown_count + 1)  # add one for the homepage
+        self.assertEqual(session.get_attachment_count(), docs_count + figure_count)
+
+        publisher.process(sample_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -74,9 +74,10 @@ def _get_page_for_document(api: ConfluenceSession, absolute_path: Path) -> Confl
 
 
 class TestPublisher(unittest.TestCase):
-    def get_processor_options(self, api: ConfluenceSession, *, skip_update: bool) -> ProcessorOptions:
+    def get_processor_options(self, api: ConfluenceSession, *, keep_hierarchy: bool, skip_update: bool) -> ProcessorOptions:
         return ProcessorOptions(
             root_page=ConfluencePageID(api.get_homepage_id("SPACE_ID")),
+            keep_hierarchy=keep_hierarchy,
             skip_update=skip_update,
             converter=ConverterOptions(
                 render_drawio=False,
@@ -99,11 +100,14 @@ class TestPublisher(unittest.TestCase):
         figure_count = len(list(figure_dir.rglob("*.*")))
 
         with MockConfluenceAPI() as api:
-            publisher = Publisher(api, self.get_processor_options(api, skip_update=True))
+            publisher = Publisher(api, self.get_processor_options(api, keep_hierarchy=False, skip_update=True))
             publisher.process(sample_dir)
 
-            self.assertEqual(api.get_page_count(), markdown_count + 1)  # add one for the homepage
-            self.assertEqual(api.get_attachment_count(), docs_count + figure_count)
+            # add one to account for homepage
+            self.assertEqual(api.get_page_count(), markdown_count + 1)
+
+            # display pre-rendering may generate images if Mermaid/PlantUML is installed
+            self.assertGreaterEqual(api.get_attachment_count(), docs_count + figure_count)
 
             publisher.process(sample_dir)
 
@@ -121,11 +125,13 @@ class TestPublisher(unittest.TestCase):
                 # no front-matter to verify if documents with inferred title are handled correctly
                 _create_document(absolute_path, source_dir, has_frontmatter=False)
 
-            Publisher(api, self.get_processor_options(api, skip_update=False)).process_directory(source_dir)
+            Publisher(api, self.get_processor_options(api, keep_hierarchy=False, skip_update=False)).process_directory(source_dir)
             self.assertEqual(api.get_page_count(), len(documents) + 1)  # add one for the homepage
 
-            for absolute_path in documents:
-                _get_page_for_document(api, absolute_path)
+            for absolute_path in reversed(documents):
+                page = _get_page_for_document(api, absolute_path)
+                api.delete_page(page.id)
+            self.assertEqual(api.get_page_count(), 1)
 
     def test_hierarchy(self) -> None:
         "Checks if a matching Confluence page hierarchy is created from a directory tree of Markdown files."
@@ -135,16 +141,17 @@ class TestPublisher(unittest.TestCase):
                 doc_a := source_dir / "index.md",
                 doc_b := source_dir / "doc1.md",
                 doc_c := source_dir / "doc2.md",
-                doc_d := source_dir / "skip" / "nested" / "index.md",
-                doc_e := source_dir / "skip" / "nested" / "doc3.md",
-                doc_f := source_dir / "skip" / "nested" / "deep" / "index.md",
+                # implicit := source_dir / "parent" / "index.md",  # this document is created on the fly
+                doc_d := source_dir / "parent" / "nested" / "index.md",
+                doc_e := source_dir / "parent" / "nested" / "doc3.md",
+                doc_f := source_dir / "parent" / "nested" / "deep" / "index.md",
             ]
 
             for absolute_path in documents:
                 _create_document(absolute_path, source_dir, has_frontmatter=True)
 
-            Publisher(api, self.get_processor_options(api, skip_update=False)).process_directory(source_dir)
-            self.assertEqual(api.get_page_count(), len(documents) + 1)  # add one for the homepage
+            Publisher(api, self.get_processor_options(api, keep_hierarchy=True, skip_update=False)).process_directory(source_dir)
+            self.assertEqual(api.get_page_count(), len(documents) + 2)  # add one for the homepage and one for the implicitly created page
 
             page_a = _get_page_for_document(api, doc_a)
             page_b = _get_page_for_document(api, doc_b)
@@ -156,9 +163,46 @@ class TestPublisher(unittest.TestCase):
             self.assertEqual(page_a.parentId, api.get_homepage_id("SPACE_ID"))
             self.assertEqual(page_b.parentId, page_a.id)
             self.assertEqual(page_c.parentId, page_a.id)
-            self.assertEqual(page_d.parentId, page_a.id)
+            self.assertNotEqual(page_d.parentId, page_a.id)
             self.assertEqual(page_e.parentId, page_d.id)
             self.assertEqual(page_f.parentId, page_d.id)
+
+            self.assertIsNotNone(page_d.parentId)
+            if page_d.parentId is not None:
+                implicit_page = api.get_page_properties(page_d.parentId)
+                self.assertEqual(page_d.parentId, implicit_page.id)
+                self.assertEqual(implicit_page.parentId, page_a.id)
+
+    def test_toplevel(self) -> None:
+        "Checks if a missing top-level document is handled correctly."
+
+        with MockConfluenceAPI() as api, _create_temporary_directory() as source_dir:
+            documents: list[Path] = [
+                doc_a := source_dir / "a" / "index.md",
+                doc_b := source_dir / "a" / "doc.md",
+                doc_c := source_dir / "b" / "skip" / "nested" / "index.md",
+                doc_d := source_dir / "b" / "skip" / "nested" / "doc.md",
+                doc_e := source_dir / "doc.md",
+            ]
+
+            for absolute_path in documents:
+                _create_document(absolute_path, source_dir, has_frontmatter=True)
+
+            Publisher(api, self.get_processor_options(api, keep_hierarchy=False, skip_update=False)).process_directory(source_dir)
+            self.assertEqual(api.get_page_count(), len(documents) + 1)  # add one for the homepage
+
+            page_a = _get_page_for_document(api, doc_a)
+            page_b = _get_page_for_document(api, doc_b)
+            page_c = _get_page_for_document(api, doc_c)
+            page_d = _get_page_for_document(api, doc_d)
+            page_e = _get_page_for_document(api, doc_e)
+
+            homepage_id = api.get_homepage_id("SPACE_ID")
+            self.assertEqual(page_a.parentId, homepage_id)
+            self.assertEqual(page_b.parentId, page_a.id)
+            self.assertEqual(page_c.parentId, homepage_id)
+            self.assertEqual(page_d.parentId, page_c.id)
+            self.assertEqual(page_e.parentId, homepage_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -6,13 +6,20 @@ Copyright 2022-2026, Levente Hunyadi
 :see: https://github.com/hunyadi/md2conf
 """
 
+import hashlib
 import logging
 import unittest
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
+from md2conf.api_base import ConfluenceSession
+from md2conf.api_types import ConfluencePageProperties
 from md2conf.options import ConfluencePageID, ConverterOptions, ProcessorOptions
 from md2conf.publisher import Publisher
-from tests.api import MockConfluenceSession
+from md2conf.scanner import Scanner
+from tests.api import MockConfluenceAPI
 
 logging.basicConfig(
     level=logging.INFO,
@@ -20,8 +27,68 @@ logging.basicConfig(
 )
 
 
+@contextmanager
+def _create_temporary_directory() -> Generator[Path]:
+    "Creates a temporary directory."
+
+    with TemporaryDirectory(dir=Path(__file__).parent) as temp_dir:
+        yield Path(temp_dir)
+
+
+def _create_document(absolute_path: Path, source_dir: Path, *, has_frontmatter: bool) -> None:
+    "Creates a Markdown document with some sample content."
+
+    absolute_path.parent.mkdir(parents=True, exist_ok=True)
+    relative_path = absolute_path.relative_to(source_dir).as_posix()
+
+    content: list[str] = [
+        f"# {relative_path}: A sample document",
+        "",
+        "This is a document without an explicitly assigned Confluence page ID or space key.",
+    ]
+
+    frontmatter: list[str] = []
+    if has_frontmatter:
+        unique_string = f"md2conf/{relative_path}"
+        digest = hashlib.sha1(unique_string.encode()).hexdigest()
+        frontmatter.extend(
+            [
+                "---",
+                f'title: "{relative_path}: {digest}"',
+                "---",
+                "",
+            ]
+        )
+
+    absolute_path.write_text("\n".join(frontmatter + content), encoding="utf-8")
+
+
+def _get_page_for_document(api: ConfluenceSession, absolute_path: Path) -> ConfluencePageProperties:
+    "Retrieves the Confluence page corresponding to the given document path."
+
+    document = Scanner().read(absolute_path)
+    props = document.properties
+    if props.page_id is None:
+        raise ValueError(f"document does not have a page ID assigned: {absolute_path}")
+    return api.get_page_properties(props.page_id)
+
+
 class TestPublisher(unittest.TestCase):
-    def test_process_sample_directory(self) -> None:
+    def get_processor_options(self, api: ConfluenceSession, *, skip_update: bool) -> ProcessorOptions:
+        return ProcessorOptions(
+            root_page=ConfluencePageID(api.get_homepage_id("SPACE_ID")),
+            skip_update=skip_update,
+            converter=ConverterOptions(
+                render_drawio=False,
+                render_mermaid=False,
+                render_plantuml=False,
+                render_latex=False,
+            ),
+        )
+
+    def test_synchronize_directory(self) -> None:
+        "Checks if a directory of Markdown files is synchronized to Confluence."
+
         parent_dir = Path(__file__).parent.parent
         sample_dir = parent_dir / "sample"
         docs_dir = sample_dir / "docs"
@@ -31,26 +98,67 @@ class TestPublisher(unittest.TestCase):
         docs_count = len(list(docs_dir.rglob("*.*")))
         figure_count = len(list(figure_dir.rglob("*.*")))
 
-        session = MockConfluenceSession()
+        with MockConfluenceAPI() as api:
+            publisher = Publisher(api, self.get_processor_options(api, skip_update=True))
+            publisher.process(sample_dir)
 
-        options = ProcessorOptions(
-            root_page=ConfluencePageID(session.get_homepage_id("SPACE_ID")),
-            skip_update=True,
-            converter=ConverterOptions(
-                render_drawio=False,
-                render_mermaid=False,
-                render_plantuml=False,
-                render_latex=False,
-            ),
-        )
+            self.assertEqual(api.get_page_count(), markdown_count + 1)  # add one for the homepage
+            self.assertEqual(api.get_attachment_count(), docs_count + figure_count)
 
-        publisher = Publisher(session, options)
-        publisher.process(sample_dir)
+            publisher.process(sample_dir)
 
-        self.assertEqual(session.get_page_count(), markdown_count + 1)  # add one for the homepage
-        self.assertEqual(session.get_attachment_count(), docs_count + figure_count)
+    def test_update(self) -> None:
+        "Checks if Markdown files are updated with a page ID when synchronized."
 
-        publisher.process(sample_dir)
+        with MockConfluenceAPI() as api, _create_temporary_directory() as source_dir:
+            documents: list[Path] = [
+                source_dir / "index.md",
+                source_dir / "doc1.md",
+                source_dir / "doc2.md",
+            ]
+
+            for absolute_path in documents:
+                # no front-matter to verify if documents with inferred title are handled correctly
+                _create_document(absolute_path, source_dir, has_frontmatter=False)
+
+            Publisher(api, self.get_processor_options(api, skip_update=False)).process_directory(source_dir)
+            self.assertEqual(api.get_page_count(), len(documents) + 1)  # add one for the homepage
+
+            for absolute_path in documents:
+                _get_page_for_document(api, absolute_path)
+
+    def test_hierarchy(self) -> None:
+        "Checks if a matching Confluence page hierarchy is created from a directory tree of Markdown files."
+
+        with MockConfluenceAPI() as api, _create_temporary_directory() as source_dir:
+            documents: list[Path] = [
+                doc_a := source_dir / "index.md",
+                doc_b := source_dir / "doc1.md",
+                doc_c := source_dir / "doc2.md",
+                doc_d := source_dir / "skip" / "nested" / "index.md",
+                doc_e := source_dir / "skip" / "nested" / "doc3.md",
+                doc_f := source_dir / "skip" / "nested" / "deep" / "index.md",
+            ]
+
+            for absolute_path in documents:
+                _create_document(absolute_path, source_dir, has_frontmatter=True)
+
+            Publisher(api, self.get_processor_options(api, skip_update=False)).process_directory(source_dir)
+            self.assertEqual(api.get_page_count(), len(documents) + 1)  # add one for the homepage
+
+            page_a = _get_page_for_document(api, doc_a)
+            page_b = _get_page_for_document(api, doc_b)
+            page_c = _get_page_for_document(api, doc_c)
+            page_d = _get_page_for_document(api, doc_d)
+            page_e = _get_page_for_document(api, doc_e)
+            page_f = _get_page_for_document(api, doc_f)
+
+            self.assertEqual(page_a.parentId, api.get_homepage_id("SPACE_ID"))
+            self.assertEqual(page_b.parentId, page_a.id)
+            self.assertEqual(page_c.parentId, page_a.id)
+            self.assertEqual(page_d.parentId, page_a.id)
+            self.assertEqual(page_e.parentId, page_d.id)
+            self.assertEqual(page_f.parentId, page_d.id)
 
 
 if __name__ == "__main__":

--- a/util/dockerhub_description.py
+++ b/util/dockerhub_description.py
@@ -92,8 +92,7 @@ def generate_description(args: Arguments) -> None:
         error(f"{TEMPLATE_FILE} not found.")
         sys.exit(1)
 
-    with open(TEMPLATE_FILE, "r") as f:
-        content = f.read()
+    content = TEMPLATE_FILE.read_text("utf-8")
 
     # Required metadata placeholders
     replacements = {

--- a/util/documentation.py
+++ b/util/documentation.py
@@ -156,8 +156,7 @@ root_path = Path(__file__).parent.parent
 os.environ["COLUMNS"] = "160"  # ensures consistent column width across platforms
 help_text = patch_help(get_help())
 readme_path = root_path / "README.md"
-with open(readme_path, "r") as input_file:
-    input_content = input_file.read()
+input_content = readme_path.read_text(encoding="utf-8")
 
 # update README.md
 text = input_content
@@ -170,8 +169,7 @@ if args.check:
     if input_content != output_content:
         raise ValueError(f"outdated file: {readme_path}")
 else:
-    with open(root_path / "README.md", "w") as output_file:
-        output_file.write(output_content)
+    (root_path / "README.md").write_text(output_content, encoding="utf-8")
 
 # generate code documentation
 if find_spec("markdown_doc") is not None:


### PR DESCRIPTION
Until recently, *md2conf* has required the presence of an `index.md` when synchronizing a directory tree of Markdown files with Confluence. While this has provided symmetry and simplified implementation, it has prevented synchronizing directory trees such as the one below:

```
source_dir/
├── Project_1/
│   ├── index.md
│   └── docs/
│       └── about.md
└── Project_2/
    └── index.md
```

Even though users specified a root page in Confluence, `source_dir` was rejected because document nodes could not be arranged into a single tree; `Project_1` and `Project_2` have no parent document because `source_dir` lacks an `index.md`. On the other hand, users rightfully expect both subtrees `Project_1` and `Project_2` to be assigned as children of the root page.

This pull request introduces a *virtual node*, which wraps top-level entries in the directory specified as a synchronization source (`mdpath`). While the virtual node is not synchronized, all of its children are.