### PR TITLE
Add an extra option to allow user supplied puppeteer configutaion for mmdc command

### DIFF
--- a/md2conf/mermaid/render.py
+++ b/md2conf/mermaid/render.py
@@ -9,6 +9,7 @@ Copyright 2022-2026, Levente Hunyadi
 import logging
 import os
 import os.path
+import shlex
 from typing import Literal
 
 from md2conf.external import cached_which, execute_subprocess
@@ -38,6 +39,28 @@ def get_mmdc() -> str:
     else:
         return "mmdc"
 
+def _get_mmdc_command() -> list[str]:
+    """
+    Returns the command to invoke Mermaid diagram converter.
+
+    :raises RuntimeError: Raised when `Mermaid CLI` is not found.
+    """
+
+    env_cmd = os.environ.get("MERMAID_CMD")
+    if env_cmd:
+        LOGGER.debug(f"Using Mermaid command: {env_cmd}")
+        return shlex.split(env_cmd)
+
+    executable = get_mmdc()
+    if cached_which(executable) is None:
+        raise RuntimeError("Mermaid CLI not found. Install Mermaid CLI from <https://github.com/mermaid-js/mermaid-cli>.")
+
+    cmd = [executable]
+    if _is_docker():
+        root = os.path.dirname(__file__)
+        cmd.extend(["-p", os.path.join(root, "puppeteer-config.json")])
+    return cmd
+
 
 def has_mmdc() -> bool:
     "True if Mermaid diagram converter is available on the OS."
@@ -52,25 +75,19 @@ def render_diagram(source: str, output_format: Literal["png", "svg"] = "png", co
     if config is None:
         config = MermaidConfigProperties()
 
-    executable = get_mmdc()
-    if cached_which(executable) is None:
-        raise RuntimeError("Mermaid CLI not found. Install Mermaid CLI from <https://github.com/mermaid-js/mermaid-cli>.")
-
-    cmd = [
-        executable,
-        "--input",
-        "-",
-        "--output",
-        "-",
-        "--outputFormat",
-        output_format,
-        "--backgroundColor",
-        "transparent",
-        "--scale",
-        str(config.scale or 2),
-    ]
-    if _is_docker():
-        root = os.path.dirname(__file__)
-        cmd.extend(["-p", os.path.join(root, "puppeteer-config.json")])
-
+    cmd = _get_mmdc_command()
+    cmd.extend(
+        [
+            "--input",
+            "-",
+            "--output",
+            "-",
+            "--outputFormat",
+            output_format,
+            "--backgroundColor",
+            "transparent",
+            "--scale",
+            str(config.scale or 2),
+        ]
+    )
     return execute_subprocess(cmd, source.encode(), application="Mermaid")


### PR DESCRIPTION
Dear md2conf developers,

I open this pull request because the embedded mmdc run failed in our containerized jenkins run. There is alraedy a docker detection in place but it fails in our use-case as the browser install path does not align with our setup.

As a workaround I added an extra option to be passed on the cli so we can add our own puppeteer config file that essentially sets the same args as you but a different browser path.

It would be great to have this merge request accepted so we don't have to maintain the fork and maybe some other users could run with a similar situation.

Alternatively some override parameter could be injected to the mmdc call directly if that makes more sense to you.

Thanks for providing this great tool,

best regards Klaus