### PR TITLE
Preserve accents in generated heading anchors

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -328,7 +328,7 @@ def title_to_slug(title: str) -> str:
     # normalize equivalent Unicode sequences and transform letters to lowercase
     s = unicodedata.normalize("NFC", title.strip()).lower()
     # remove punctuation except spaces, hyphens and Unicode word characters
-    s = re.sub(_PUNCTUATION_REMOVE_REGEXP, "", s)
+    s = _PUNCTUATION_REMOVE_REGEXP.sub("", s)
     # collapse whitespace to hyphens
     s = _SPACE_COLLAPSE_REGEXP.sub("-", s)
     return s

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -275,12 +275,13 @@ class NodeVisitor(ABC):
 
 
 _DISALLOWED_CHAR_REGEXP = re.compile(r"[^\sa-z0-9_-]")
+_PUNCTUATION_REMOVE_REGEXP = re.compile(r"[^\s\w-]")
 _SPACE_COLLAPSE_REGEXP = re.compile(r"\s+")
 
 
 def title_to_identifier(title: str) -> str:
     """
-    Converts a section heading title to a GitHub-style Markdown same-page anchor.
+    Converts a section heading title to a Markdown same-page anchor.
 
     :param title: Heading title text without formatting.
     """
@@ -294,20 +295,42 @@ def title_to_identifier(title: str) -> str:
     return s
 
 
-def title_to_slug(title: str) -> str:
+def title_to_ascii_slug(title: str) -> str:
     """
-    Converts a section heading title to a GitHub-style Markdown same-page anchor.
+    Converts a section heading title to a Markdown same-page anchor with accent removal.
 
     :param title: Heading title text without formatting.
+    """
+
+    s = title.strip()
+    # normalize to NFD (decomposes accents)
+    s = unicodedata.normalize("NFD", s)
+    # remove non-spacing combining diacritic marks (zero advance width) (Unicode category `Mn`)
+    s = "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
+    # transform to lowercase
+    s = s.lower()
+    # remove punctuation except spaces and hyphens
+    s = _DISALLOWED_CHAR_REGEXP.sub("", s)
+    # collapse whitespace to hyphens
+    s = _SPACE_COLLAPSE_REGEXP.sub("-", s)
+
+    return s
+
+
+def title_to_slug(title: str) -> str:
+    """
+    Converts a section heading title to a Markdown same-page anchor retaining Unicode word characters.
+
+    :param title: Heading title text without formatting.
+    :returns: A slug compatible with GitHub and GitLab flavor Markdown.
     """
 
     # normalize equivalent Unicode sequences and transform letters to lowercase
     s = unicodedata.normalize("NFC", title.strip()).lower()
     # remove punctuation except spaces, hyphens and Unicode word characters
-    s = re.sub(r"[^\s\w-]", "", s)
+    s = re.sub(_PUNCTUATION_REMOVE_REGEXP, "", s)
     # collapse whitespace to hyphens
     s = _SPACE_COLLAPSE_REGEXP.sub("-", s)
-
     return s
 
 

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -296,20 +296,15 @@ def title_to_identifier(title: str) -> str:
 
 def title_to_slug(title: str) -> str:
     """
-    Converts a section heading title to a GitHub-style Markdown same-page anchor with accent removal.
+    Converts a section heading title to a GitHub-style Markdown same-page anchor.
 
     :param title: Heading title text without formatting.
     """
 
-    s = title.strip()
-    # normalize to NFD (decomposes accents)
-    s = unicodedata.normalize("NFD", s)
-    # remove nonspacing combining diacritic marks (zero advance width) (Unicode category `Mn`)
-    s = "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
-    # transform to lowercase
-    s = s.lower()
-    # remove punctuation except spaces and hyphens
-    s = _DISALLOWED_CHAR_REGEXP.sub("", s)
+    # normalize equivalent Unicode sequences and transform letters to lowercase
+    s = unicodedata.normalize("NFC", title.strip()).lower()
+    # remove punctuation except spaces, hyphens and Unicode word characters
+    s = re.sub(r"[^\s\w-]", "", s)
     # collapse whitespace to hyphens
     s = _SPACE_COLLAPSE_REGEXP.sub("-", s)
 

--- a/tests/source/anchors.md
+++ b/tests/source/anchors.md
@@ -4,7 +4,7 @@
 
 [Project page](https://github.com/hunyadi/md2conf)
 
-[Link to Subsection 1](#subsection-1) | [Link to Subsection 2](#subsection-links) | [Link to Subsection 3](#subsection-empty) | [Link to Subsection 4](#arvizturo-tukorfurogep)
+[Link to Subsection 1](#subsection-1) | [Link to Subsection 2](#subsection-links) | [Link to Subsection 3](#subsection-empty) | [Link to Subsection 4](#árvíztűrő-tükörfúrógép)
 
 ### Subsection 1
 

--- a/tests/target/anchors.xml
+++ b/tests/target/anchors.xml
@@ -5,7 +5,7 @@
 </ac:structured-macro>
 <h2><ac:structured-macro ac:name="anchor" ac:schema-version="1"><ac:parameter ac:name="">anchors</ac:parameter></ac:structured-macro>Anchors</h2>
 <a href="https://github.com/hunyadi/md2conf" data-card-appearance="block">Project page</a>
-<p><ac:link ac:anchor="subsection-1"><ac:link-body>Link to Subsection 1</ac:link-body></ac:link> | <ac:link ac:anchor="subsection-links"><ac:link-body>Link to Subsection 2</ac:link-body></ac:link> | <ac:link ac:anchor="subsection-empty"><ac:link-body>Link to Subsection 3</ac:link-body></ac:link> | <ac:link ac:anchor="arvizturo-tukorfurogep"><ac:link-body>Link to Subsection 4</ac:link-body></ac:link></p>
+<p><ac:link ac:anchor="subsection-1"><ac:link-body>Link to Subsection 1</ac:link-body></ac:link> | <ac:link ac:anchor="subsection-links"><ac:link-body>Link to Subsection 2</ac:link-body></ac:link> | <ac:link ac:anchor="subsection-empty"><ac:link-body>Link to Subsection 3</ac:link-body></ac:link> | <ac:link ac:anchor="árvíztűrő-tükörfúrógép"><ac:link-body>Link to Subsection 4</ac:link-body></ac:link></p>
 <h3><ac:structured-macro ac:name="anchor" ac:schema-version="1"><ac:parameter ac:name="">subsection-1</ac:parameter></ac:structured-macro>Subsection 1</h3>
 <p><ac:link ac:anchor="anchors"><ac:link-body>Link to top</ac:link-body></ac:link></p>
 <h3><ac:structured-macro ac:name="anchor" ac:schema-version="1"><ac:parameter ac:name="">subsection-links</ac:parameter></ac:structured-macro>Subsection 2</h3>
@@ -17,5 +17,5 @@
 <p><ac:link><ri:attachment ri:filename="docs_sample.ods"/><ac:link-body>LibreOffice Calc document</ac:link-body></ac:link></p>
 <h3><ac:structured-macro ac:name="anchor" ac:schema-version="1"><ac:parameter ac:name="">subsection-empty</ac:parameter></ac:structured-macro>Subsection <strong>3</strong></h3>
 <p><ac:link ac:anchor="anchors"><ac:link-body>Link to top</ac:link-body></ac:link></p>
-<h3><ac:structured-macro ac:name="anchor" ac:schema-version="1"><ac:parameter ac:name="">arvizturo-tukorfurogep</ac:parameter></ac:structured-macro>Árvíztűrő tükörfúrógép</h3>
+<h3><ac:structured-macro ac:name="anchor" ac:schema-version="1"><ac:parameter ac:name="">árvíztűrő-tükörfúrógép</ac:parameter></ac:structured-macro>Árvíztűrő tükörfúrógép</h3>
 <p>Subsection whose title contains international characters.</p>

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -15,7 +15,7 @@ from typing import Literal
 
 from md2conf.attachment import attachment_name
 from md2conf.coalesce import coalesce_dataclass, coalesce_json
-from md2conf.converter import title_to_identifier, title_to_slug
+from md2conf.converter import title_to_ascii_slug, title_to_identifier, title_to_slug
 from md2conf.formatting import display_width
 from md2conf.latex import LATEX_ENABLED, render_latex
 from md2conf.png import extract_png_dimensions, remove_png_chunks
@@ -104,13 +104,31 @@ class TestUnit(TypedTestCase):
         self.assertEqual(title_to_identifier("Hello -- World!!"), "hello----world")
         self.assertEqual(title_to_identifier("árvíztűrő tükörfúrógép"), "rvztr-tkrfrgp")  # spellchecker:disable-line
 
+    def test_title_to_ascii_slug(self) -> None:
+        self.assertEqual(title_to_ascii_slug("This is  a Heading  "), "this-is-a-heading")
+        self.assertEqual(title_to_ascii_slug("What's New in v2.0?"), "whats-new-in-v20")
+        self.assertEqual(title_to_ascii_slug("C++ & C# Comparison"), "c-c-comparison")
+        self.assertEqual(title_to_ascii_slug("Hello -- World!!"), "hello----world")
+        # spellchecker: disable
+        self.assertEqual(title_to_ascii_slug("paramètres"), "parametres")
+        self.assertEqual(title_to_ascii_slug("árvíztűrő tükörfúrógép"), "arvizturo-tukorfurogep")
+        # spellchecker: enable
+
     def test_title_to_slug(self) -> None:
         self.assertEqual(title_to_slug("This is  a Heading  "), "this-is-a-heading")
         self.assertEqual(title_to_slug("What's New in v2.0?"), "whats-new-in-v20")
         self.assertEqual(title_to_slug("C++ & C# Comparison"), "c-c-comparison")
         self.assertEqual(title_to_slug("Hello -- World!!"), "hello----world")
+        # spellchecker: disable
         self.assertEqual(title_to_slug("paramètres"), "paramètres")
-        self.assertEqual(title_to_slug("árvíztűrő tükörfúrógép"), "árvíztűrő-tükörfúrógép")  # spellchecker:disable-line
+        self.assertEqual(title_to_slug("árvíztűrő tükörfúrógép"), "árvíztűrő-tükörfúrógép")
+        # spellchecker: enable
+
+        self.assertEqual(title_to_slug("spaces in it"), "spaces-in-it")
+        self.assertEqual(title_to_slug("a :thumbsup: in it"), "a-thumbsup-in-it")
+        self.assertEqual(title_to_slug("Unicode: 한글"), "unicode-한글")
+        self.assertEqual(title_to_slug("3.5 (and parentheses)"), "35-and-parentheses")
+        self.assertEqual(title_to_slug("multiple  spaces and --- hyphens_and_underscores"), "multiple-spaces-and-----hyphens_and_underscores")
 
     @unittest.skipUnless(LATEX_ENABLED, "matplotlib not installed")
     def test_formula(self) -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -109,8 +109,8 @@ class TestUnit(TypedTestCase):
         self.assertEqual(title_to_slug("What's New in v2.0?"), "whats-new-in-v20")
         self.assertEqual(title_to_slug("C++ & C# Comparison"), "c-c-comparison")
         self.assertEqual(title_to_slug("Hello -- World!!"), "hello----world")
-        self.assertEqual(title_to_slug("paramètres"), "parametres")
-        self.assertEqual(title_to_slug("árvíztűrő tükörfúrógép"), "arvizturo-tukorfurogep")  # spellchecker:disable-line
+        self.assertEqual(title_to_slug("paramètres"), "paramètres")
+        self.assertEqual(title_to_slug("árvíztűrő tükörfúrógép"), "árvíztűrő-tükörfúrógép")  # spellchecker:disable-line
 
     @unittest.skipUnless(LATEX_ENABLED, "matplotlib not installed")
     def test_formula(self) -> None:


### PR DESCRIPTION
## Summary
- preserve Unicode word characters in inferred heading anchors
- normalize equivalent Unicode sequences before slug generation
- cover accented same-page links in the conversion fixture and slug unit tests

## Why
GitHub-style same-page links retain accented characters, while md2conf removed them from generated Confluence anchors. The resulting link and target identifiers did not match.

## Tests
- `.venv/bin/python -m unittest tests.test_unit.TestUnit.test_title_to_slug tests.test_conversion.TestConversion.test_heading_anchors`
- `.venv/bin/python -m unittest discover -s tests` (112 passed, 8 skipped)
- `PYTHON=.venv/bin/python ./check.sh`
- `git diff --check`

Fixes #279