### PR TITLE
Detect attachment changes with checksums

### DIFF
--- a/md2conf/api_base.py
+++ b/md2conf/api_base.py
@@ -150,6 +150,36 @@ class ConfluenceSession(ABC):
     @abstractmethod
     def delete_attachment(self, attachment_id: str) -> None: ...
 
+    @property
+    @abstractmethod
+    def supports_attachment_content_properties(self) -> bool:
+        """Whether attachment content properties are available in this Confluence API."""
+
+        ...
+
+    @abstractmethod
+    def get_content_property_for_attachment(self, attachment_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
+        """
+        Retrieves a content property for an attachment.
+
+        :param attachment_id: The attachment ID.
+        :param key: The name of the property to fetch (with case-sensitive match).
+        :returns: The content property value, or `None` if not found.
+        """
+
+        ...
+
+    @abstractmethod
+    def update_content_property_for_attachment(self, attachment_id: str, property: ConfluenceContentProperty) -> None:
+        """
+        Creates or updates a content property for an attachment.
+
+        :param attachment_id: The attachment ID.
+        :param property: Content property data to assign.
+        """
+
+        ...
+
     @abstractmethod
     def upload_attachment(
         self,

--- a/md2conf/api_v1.py
+++ b/md2conf/api_v1.py
@@ -229,6 +229,19 @@ class ConfluenceSessionV1(ConfluenceSessionShared):
             else:
                 raise
 
+    @property
+    @override
+    def supports_attachment_content_properties(self) -> bool:
+        return False
+
+    @override
+    def get_content_property_for_attachment(self, attachment_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
+        raise NotImplementedError("attachment content properties are not supported")
+
+    @override
+    def update_content_property_for_attachment(self, attachment_id: str, property: ConfluenceContentProperty) -> None:
+        raise NotImplementedError("attachment content properties are not supported")
+
     @override
     def get_page_properties_by_title(self, title: str, *, space_id: str | None = None, space_key: str | None = None) -> ConfluencePageProperties:
         LOGGER.info("Looking up page with title: %s", title)

--- a/md2conf/api_v2.py
+++ b/md2conf/api_v2.py
@@ -191,6 +191,40 @@ class ConfluenceSessionV2(ConfluenceSessionShared):
             else:
                 raise
 
+    @property
+    @override
+    def supports_attachment_content_properties(self) -> bool:
+        return True
+
+    @override
+    def get_content_property_for_attachment(self, attachment_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
+        path = f"/attachments/{attachment_id}/properties"
+        results = self._fetch_v2(path, query={"key": key})
+        properties = json_to_object(list[ConfluenceIdentifiedContentProperty], results)
+        if len(properties) == 1:
+            return properties.pop()
+        else:
+            return None
+
+    @override
+    def update_content_property_for_attachment(self, attachment_id: str, property: ConfluenceContentProperty) -> None:
+        old_property = self.get_content_property_for_attachment(attachment_id, property.key)
+        if old_property is None:
+            path = f"/attachments/{attachment_id}/properties"
+            self._post(ConfluenceVersion.VERSION_2, path, property, ConfluenceIdentifiedContentProperty)
+        elif old_property.value != property.value:
+            path = f"/attachments/{attachment_id}/properties/{old_property.id}"
+            self._put(
+                ConfluenceVersion.VERSION_2,
+                path,
+                ConfluenceVersionedContentProperty(
+                    key=property.key,
+                    value=property.value,
+                    version=ConfluenceContentVersion(number=old_property.version.number + 1),
+                ),
+                ConfluenceIdentifiedContentProperty,
+            )
+
     @override
     def get_page_properties_by_title(self, title: str, *, space_id: str | None = None, space_key: str | None = None) -> ConfluencePageProperties:
         LOGGER.info("Looking up page with title: %s", title)

--- a/md2conf/publisher.py
+++ b/md2conf/publisher.py
@@ -19,7 +19,7 @@ from .collection import ConfluenceUserCollection
 from .compatibility import override, path_relative_to
 from .converter import ConfluenceDocument, apply_generated_by_template, get_orderless_elements, get_volatile_attributes, get_volatile_elements
 from .csf import AC_ATTR, ElementType, elements_from_string
-from .environment import PageError
+from .environment import ArgumentError, PageError
 from .metadata import ConfluencePageMetadata
 from .options import ConfluencePageID, ProcessorOptions
 from .options_converter import ConverterOptions
@@ -404,12 +404,24 @@ class SynchronizingProcessor(Processor):
         base_path = path.parent
         for image_data in document.images:
             name = attachment_name(path_relative_to(image_data.path, base_path))
-            self.api.upload_attachment(page_id, name, attachment_path=image_data.path, comment=image_data.description)
+            self._synchronize_attachment(
+                page_id,
+                attachments.get(name),
+                name,
+                attachment_path=image_data.path,
+                comment=image_data.description,
+            )
             attachments.pop(name, None)
 
         # update attachments with embedded content
         for name, file_data in document.embedded_files.items():
-            self.api.upload_attachment(page_id, name, raw_data=file_data.data, comment=file_data.description)
+            self._synchronize_attachment(
+                page_id,
+                attachments.get(name),
+                name,
+                raw_data=file_data.data,
+                comment=file_data.description,
+            )
             attachments.pop(name, None)
 
         # delete attachments no longer referenced
@@ -441,6 +453,60 @@ class SynchronizingProcessor(Processor):
         else:
             if source_tag is None or source_tag != target_tag:
                 self.api.update_content_properties_for_page(page.id, props, keep_existing=True)
+
+    def _synchronize_attachment(
+        self,
+        page_id: str,
+        attachment_id: str | None,
+        attachment_name: str,
+        *,
+        attachment_path: Path | None = None,
+        raw_data: bytes | None = None,
+        comment: str | None = None,
+    ) -> None:
+        """Synchronizes an attachment using a checksum when the API supports content properties."""
+
+        if attachment_path is None and raw_data is None:
+            raise ArgumentError("required: `attachment_path` or `raw_data`")
+        if attachment_path is not None and raw_data is not None:
+            raise ArgumentError("expected: either `attachment_path` or `raw_data`")
+
+        if not self.api.supports_attachment_content_properties:
+            self.api.upload_attachment(page_id, attachment_name, attachment_path=attachment_path, raw_data=raw_data, comment=comment)
+            return
+
+        digest = hashlib.md5()
+        if attachment_path is not None:
+            if not attachment_path.is_file():
+                raise PageError(f"file not found: {attachment_path}")
+            with attachment_path.open("rb") as attachment_file:
+                while chunk := attachment_file.read(1024 * 1024):
+                    digest.update(chunk)
+        elif raw_data is not None:
+            digest.update(raw_data)
+        else:
+            raise AssertionError("parameter match not exhaustive")
+
+        source_digest = digest.hexdigest()
+        if attachment_id is not None:
+            property = self.api.get_content_property_for_attachment(attachment_id, CONTENT_PROPERTY_TAG)
+            if property is not None and property.value == source_digest:
+                LOGGER.info("Up-to-date attachment (matching checksum): %s", attachment_name)
+                return
+
+        self.api.upload_attachment(
+            page_id,
+            attachment_name,
+            attachment_path=attachment_path,
+            raw_data=raw_data,
+            comment=comment,
+            force=True,
+        )
+        attachment = self.api.get_attachment_by_name(page_id, attachment_name)
+        self.api.update_content_property_for_attachment(
+            attachment.id,
+            ConfluenceContentProperty(CONTENT_PROPERTY_TAG, source_digest),
+        )
 
     def _has_changes(self, page: ConfluencePage, tag: ConfluenceMarkdownTag | None, title: str, root: ElementType, source_digest: str) -> bool:
         "True if the Confluence Storage Format content generated from the Markdown source file matches the Confluence target page content."

--- a/tests/api.py
+++ b/tests/api.py
@@ -99,6 +99,18 @@ class MockConfluenceSession(ConfluenceSession):
             )
             """
         )
+        self._db.execute(
+            """
+            CREATE TABLE attachmentContentProperties (
+                id TEXT PRIMARY KEY,
+                attachmentId TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                UNIQUE (attachmentId, key)
+            )
+            """
+        )
         self._create_page(
             page_id=HOMEPAGE_ID,
             title="Home",
@@ -308,6 +320,43 @@ class MockConfluenceSession(ConfluenceSession):
         LOGGER.debug("attachment_id: %s", attachment_id)
         self._get_attachment_row(attachment_id)
         self._db.execute("DELETE FROM attachments WHERE id = ?", (attachment_id,))
+        self._db.commit()
+
+    @property
+    @override
+    def supports_attachment_content_properties(self) -> bool:
+        return True
+
+    @override
+    def get_content_property_for_attachment(self, attachment_id: str, key: str) -> ConfluenceIdentifiedContentProperty | None:
+        LOGGER.debug("attachment_id: %s, property_key: %s", attachment_id, key)
+        row: sqlite3.Row | None = self._db.execute(
+            "SELECT id, key, value, version FROM attachmentContentProperties WHERE attachmentId = ? AND key = ? LIMIT 1",
+            (attachment_id, key),
+        ).fetchone()
+        return self._row_to_identified_content_property(row) if row is not None else None
+
+    @override
+    def update_content_property_for_attachment(self, attachment_id: str, property: ConfluenceContentProperty) -> None:
+        old_property = self.get_content_property_for_attachment(attachment_id, property.key)
+        if old_property is None:
+            property_id = f"PROP_{uuid4().hex[:8].upper()}"
+            self._db.execute(
+                "INSERT INTO attachmentContentProperties (id, attachmentId, key, value, version) VALUES (?, ?, ?, ?, ?)",
+                (property_id, attachment_id, property.key, json.dumps(property.value), 1),
+            )
+        elif old_property.value != property.value:
+            self._db.execute(
+                "UPDATE attachmentContentProperties SET key = ?, value = ?, version = ? WHERE id = ? AND attachmentId = ?",
+                (property.key, json.dumps(property.value), old_property.version.number + 1, old_property.id, attachment_id),
+            )
+        self._db.commit()
+
+    def remove_content_property_from_attachment(self, attachment_id: str, property_id: str) -> None:
+        self._db.execute(
+            "DELETE FROM attachmentContentProperties WHERE id = ? AND attachmentId = ?",
+            (property_id, attachment_id),
+        )
         self._db.commit()
 
     @override

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -112,6 +112,57 @@ class TestPublisher(unittest.TestCase):
 
             publisher.process(sample_dir)
 
+    def _synchronize_attachment(
+        self,
+        *,
+        remove_checksum_after_first_upload: bool,
+        change_content: bool,
+    ) -> None:
+        with MockConfluenceAPI() as api, _create_temporary_directory() as source_dir:
+            document_path = source_dir / "index.md"
+            attachment_path = source_dir / "diagram.png"
+            document_path.write_text("# Diagram\n\n![diagram](diagram.png)\n", encoding="utf-8")
+            attachment_data = (Path(__file__).parent / "source" / "figure" / "raster.png").read_bytes()
+            attachment_path.write_bytes(attachment_data)
+
+            publisher = Publisher(api, self.get_processor_options(api, keep_hierarchy=False, skip_update=True))
+            publisher.process_directory(source_dir)
+
+            page = api.get_page_properties_by_title("Diagram")
+            attachment = api.get_attachment_by_name(page.id, "diagram.png")
+            first_version = attachment.version.number
+
+            if remove_checksum_after_first_upload:
+                property = api.get_content_property_for_attachment(attachment.id, "md2conf")
+                self.assertIsNotNone(property)
+                if property is not None:
+                    api.remove_content_property_from_attachment(attachment.id, property.id)
+            if change_content:
+                attachment_path.write_bytes(attachment_data[:-1] + bytes([attachment_data[-1] ^ 1]))
+            publisher.process_directory(source_dir)
+            changed_version = api.get_attachment_by_name(page.id, "diagram.png").version.number
+            self.assertEqual(changed_version, first_version + 1)
+
+            publisher.process_directory(source_dir)
+            unchanged_version = api.get_attachment_by_name(page.id, "diagram.png").version.number
+            self.assertEqual(unchanged_version, changed_version)
+
+    def test_synchronize_same_size_attachment_by_checksum(self) -> None:
+        """Checks if REST API v2 detects attachment changes whose byte length is unchanged."""
+
+        self._synchronize_attachment(
+            remove_checksum_after_first_upload=False,
+            change_content=True,
+        )
+
+    def test_initialize_missing_attachment_checksum(self) -> None:
+        """Checks if REST API v2 initializes a missing checksum with one upload."""
+
+        self._synchronize_attachment(
+            remove_checksum_after_first_upload=True,
+            change_content=False,
+        )
+
     def test_update(self) -> None:
         "Checks if Markdown files are updated with a page ID when synchronized."
 


### PR DESCRIPTION
## Summary

- store a checksum as an attachment content property when using Confluence Cloud REST API v2
- upload same-size attachments when their content changes and skip matching checksums
- retain the existing file-size fallback for Data Center and Server REST API v1

## Testing

- `python -m unittest tests.test_api_v2 tests.test_publisher`
- `python -m unittest discover -s tests`
- `PYTHONPATH=. PYTHON=.venv/bin/python ./check.sh`

Closes #278
