### PR TITLE
Include converter version in page digest

### DIFF
--- a/md2conf/publisher.py
+++ b/md2conf/publisher.py
@@ -11,6 +11,7 @@ import logging
 from dataclasses import dataclass, fields
 from pathlib import Path
 
+from . import __version__
 from .api_base import ConfluenceSession
 from .api_types import ConfluenceCommentStatus, ConfluenceContentProperty, ConfluenceLabel, ConfluencePage, ConfluenceStatus
 from .attachment import attachment_name
@@ -139,9 +140,11 @@ class AggregateOptions(ConverterOptions):
     Options that impact the Confluence Storage Format output that is synchronized.
 
     :param generated_by: Text to use as the generated-by prompt (or `None` to omit a prompt).
+    :param converter_version: md2conf version that generated the output.
     """
 
     generated_by: str | None = None
+    converter_version: str = __version__
 
     @classmethod
     def create(cls, relative_path: Path, options: ConverterOptions, generated_by: str | None) -> "AggregateOptions":

--- a/md2conf/publisher.py
+++ b/md2conf/publisher.py
@@ -18,7 +18,7 @@ from .attachment import attachment_name
 from .coalesce import coalesce_json
 from .collection import ConfluenceUserCollection
 from .comment import MergeResult, merge_comments, remove_comments
-from .compatibility import override, path_relative_to
+from .compatibility import LiteralString, override, path_relative_to
 from .converter import ConfluenceDocument, apply_generated_by_template, get_orderless_elements, get_volatile_attributes, get_volatile_elements
 from .csf import ElementType, elements_from_string, elements_to_string
 from .environment import ArgumentError, PageError
@@ -140,11 +140,9 @@ class AggregateOptions(ConverterOptions):
     Options that impact the Confluence Storage Format output that is synchronized.
 
     :param generated_by: Text to use as the generated-by prompt (or `None` to omit a prompt).
-    :param converter_version: md2conf version that generated the output.
     """
 
     generated_by: str | None = None
-    converter_version: str = __version__
 
     @classmethod
     def create(cls, relative_path: Path, options: ConverterOptions, generated_by: str | None) -> "AggregateOptions":
@@ -164,15 +162,28 @@ class DocumentHasher:
     Aggregates input that impact the Confluence Storage Format output that is synchronized.
     """
 
+    version: LiteralString
     options: AggregateOptions
     absolute_path: Path
 
-    def __init__(self, options: AggregateOptions, absolute_path: Path) -> None:
+    def __init__(self, version: LiteralString, options: AggregateOptions, absolute_path: Path) -> None:
+        """
+        Initializes a new document hasher instance.
+
+        :param version: Semantic version string of the library that is generating the hash.
+            Used to capture behavior changes across library versions.
+        :param options: User-configured options that impact the Confluence Storage Format output.
+        :param absolute_path: Absolute path to the Markdown source file.
+        """
+
+        self.version = version
         self.options = options
         self.absolute_path = absolute_path
 
     def digest(self) -> str:
         m = hashlib.md5()
+        m.update(self.version.encode("utf-8"))
+        m.update(b"\n")
         m.update(object_to_json_payload(self.options))
         m.update(b"\n")
         m.update(self.absolute_path.read_bytes())
@@ -355,6 +366,7 @@ class SynchronizingProcessor(Processor):
 
         # compute hash to help detect if document content or conversion options have changed
         source_digest = DocumentHasher(
+            __version__,
             AggregateOptions.create(path.relative_to(self.root_dir), self.options.converter, self.options.generated_by),
             path,
         ).digest()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -76,14 +76,14 @@ def _get_page_for_document(api: ConfluenceSession, absolute_path: Path) -> Confl
 
 class TestPublisher(unittest.TestCase):
     def test_document_hash_includes_converter_version(self) -> None:
-        """Checks if a converter release invalidates previously generated content."""
+        "Checks if the document hash changes when the library version changes."
 
         with _create_temporary_directory() as source_dir:
             document_path = source_dir / "index.md"
             document_path.write_text("# Document\n", encoding="utf-8")
 
-            current_digest = DocumentHasher(AggregateOptions(converter_version="current"), document_path).digest()
-            previous_digest = DocumentHasher(AggregateOptions(converter_version="previous"), document_path).digest()
+            current_digest = DocumentHasher("1.0.0", AggregateOptions(), document_path).digest()
+            previous_digest = DocumentHasher("2.0.0", AggregateOptions(), document_path).digest()
 
             self.assertNotEqual(current_digest, previous_digest)
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -18,7 +18,7 @@ from md2conf.api_base import ConfluenceSession
 from md2conf.api_types import ConfluencePageProperties
 from md2conf.options import ConfluencePageID, ProcessorOptions
 from md2conf.options_converter import ConverterOptions
-from md2conf.publisher import Publisher
+from md2conf.publisher import AggregateOptions, DocumentHasher, Publisher
 from md2conf.scanner import Scanner
 from tests.api import MockConfluenceAPI
 
@@ -75,6 +75,18 @@ def _get_page_for_document(api: ConfluenceSession, absolute_path: Path) -> Confl
 
 
 class TestPublisher(unittest.TestCase):
+    def test_document_hash_includes_converter_version(self) -> None:
+        """Checks if a converter release invalidates previously generated content."""
+
+        with _create_temporary_directory() as source_dir:
+            document_path = source_dir / "index.md"
+            document_path.write_text("# Document\n", encoding="utf-8")
+
+            current_digest = DocumentHasher(AggregateOptions(converter_version="current"), document_path).digest()
+            previous_digest = DocumentHasher(AggregateOptions(converter_version="previous"), document_path).digest()
+
+            self.assertNotEqual(current_digest, previous_digest)
+
     def get_processor_options(self, api: ConfluenceSession, *, keep_hierarchy: bool, skip_update: bool) -> ProcessorOptions:
         return ProcessorOptions(
             root_page=ConfluencePageID(api.get_homepage_id("SPACE_ID")),


### PR DESCRIPTION
The digest that decides whether a page needs to be resynchronized was based only on the Markdown source and conversion options, so upgrading md2conf could leave a previously published page stale until its source changed again. Folding the converter version into the digest makes a release that changes how content is rendered force affected pages to resynchronize on the next run.

Fixes  #285