### PR TITLE
Handle consecutive GitHub alerts

### DIFF
--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -462,10 +462,15 @@ def transform_skip_comments_in_html(html: str) -> str:
 _FOOTNOTE_REF_REGEXP = re.compile(r"^fnref(\d*):(.+)$")
 _TASKLIST_REGEXP = re.compile(r"^\[([x X])\]")
 _GITHUB_ALERT_REGEXP = re.compile(r"^\[!([A-Z]+)\]\s*")
-_GITHUB_ALERT_TO_CSF = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
 
 
-def split_github_alert_groups(root: ElementType) -> None:
+def _is_alert_paragraph(element: ElementType) -> bool:
+    "True if the element is a paragraph that starts with a GitHub alert marker `[!TYPE]`."
+
+    return element.tag == "p" and element.text is not None and _GITHUB_ALERT_REGEXP.match(element.text) is not None
+
+
+def _split_github_alert_groups(root: ElementType) -> None:
     """
     Splits a block-quote with several back-to-back `[!TYPE]` alerts into one block-quote per alert.
 
@@ -481,29 +486,25 @@ def split_github_alert_groups(root: ElementType) -> None:
     :param root: Root of the parsed HTML element tree, mutated in place.
     """
 
-    for blockquote in list(root.iter("blockquote")):
+    for blockquote in list(root.iterchildren("blockquote")):
         children = list(blockquote)
-        if not children or children[0].tag != "p" or not _GITHUB_ALERT_REGEXP.match(children[0].text or ""):
+        if not children or not _is_alert_paragraph(children[0]):
             continue
 
-        group_count = sum(1 for e in children if e.tag == "p" and _GITHUB_ALERT_REGEXP.match(e.text or ""))
+        group_count = sum(1 for e in children if _is_alert_paragraph(e))
         if group_count < 2:
-            continue
-
-        parent = blockquote.getparent()
-        if parent is None:
             continue
 
         groups: list[ElementType] = []
         for element in children:
-            if element.tag == "p" and _GITHUB_ALERT_REGEXP.match(element.text or ""):
+            if _is_alert_paragraph(element):
                 groups.append(blockquote.makeelement(blockquote.tag, blockquote.attrib))
             blockquote.remove(element)
             groups[-1].append(element)
 
-        index = parent.index(blockquote)
+        index = root.index(blockquote)
         groups[-1].tail = blockquote.tail
-        parent[index : index + 1] = groups
+        root[index : index + 1] = groups
 
 
 @dataclass(frozen=True)
@@ -1147,7 +1148,8 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         if self.options.use_panel:
             return self._transform_panel(blockquote, alert.lower())
         else:
-            class_name = _GITHUB_ALERT_TO_CSF.get(alert)
+            alert_to_csf = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
+            class_name = alert_to_csf.get(alert)
             if class_name is None:
                 raise DocumentError(blockquote, f"unsupported GitHub alert: {alert}")
 
@@ -2009,7 +2011,7 @@ class ConfluenceDocument:
             raise ConversionError(f"failed to convert Markdown file: {path}") from ex
 
         # normalize back-to-back GitHub alerts into separate block-quotes before the tree visitor runs
-        split_github_alert_groups(self.root)
+        _split_github_alert_groups(self.root)
 
         # configure HTML-to-Confluence converter
         converter_options = copy.deepcopy(self.options.converter)

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -1086,11 +1086,37 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         if len(blockquote) < 1:
             raise DocumentError(blockquote, "empty GitHub alert")
 
+        pattern = re.compile(r"^\[!([A-Z]+)\]\s*")
+        alert_groups: list[tuple[str, list[ElementType]]] = []
+        for element in blockquote:
+            match = pattern.match(element.text or "") if element.tag == "p" else None
+            if match is not None:
+                alert_element = copy.deepcopy(element)
+                alert_element.text = alert_element.text[len(match.group(0)) :] if alert_element.text is not None else None
+                alert_groups.append((match.group(1), [alert_element]))
+            elif alert_groups:
+                alert_groups[-1][1].append(copy.deepcopy(element))
+
+        if len(alert_groups) > 1:
+            alert_elements: list[ElementType] = []
+            alert_to_csf = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
+            for alert, elements in alert_groups:
+                alert_block = copy.deepcopy(blockquote)
+                alert_block[:] = elements
+                if self.options.use_panel:
+                    alert_elements.append(self._transform_panel(alert_block, alert.lower()))
+                else:
+                    class_name = alert_to_csf.get(alert)
+                    if class_name is None:
+                        raise DocumentError(blockquote, f"unsupported GitHub alert: {alert}")
+                    alert_elements.append(self._transform_alert(alert_block, class_name))
+
+            return AC_ELEM("div", {}, *alert_elements)
+
         content = blockquote[0]
         if content.text is None:
             raise DocumentError(blockquote, "empty content for GitHub alert")
 
-        pattern = re.compile(r"^\[!([A-Z]+)\]\s*")
         match = pattern.match(content.text)
         if not match:
             raise DocumentError(blockquote, "not a GitHub alert")

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -461,6 +461,8 @@ def transform_skip_comments_in_html(html: str) -> str:
 
 _FOOTNOTE_REF_REGEXP = re.compile(r"^fnref(\d*):(.+)$")
 _TASKLIST_REGEXP = re.compile(r"^\[([x X])\]")
+_GITHUB_ALERT_REGEXP = re.compile(r"^\[!([A-Z]+)\]\s*")
+_GITHUB_ALERT_TO_CSF = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
 
 
 @dataclass(frozen=True)
@@ -1075,6 +1077,54 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
                 AC_ELEM("rich-text-body", {}, *list(elem)),
             )
 
+    def _split_github_alert_blocks(self, blockquote: ElementType) -> list[ElementType]:
+        """
+        Splits a block-quote with several back-to-back `[!TYPE]` alerts into one block-quote per alert.
+
+        GitHub alerts written without a blank line between them (e.g. a `[!WARNING]` paragraph directly
+        followed by a `[!NOTE]` paragraph within the same block-quote) parse as a single block-quote with
+        multiple embedded paragraphs, each starting with its own `[!TYPE]` marker. This moves each such
+        paragraph (and the non-alert content that follows it) into its own block-quote, so the existing
+        single-alert logic can process each one independently.
+
+        :param blockquote: A `<blockquote>` element, possibly holding more than one `[!TYPE]`-tagged alert.
+        :returns: One block-quote per alert found; a single-element list when there is only one alert.
+        """
+
+        blocks: list[ElementType] = []
+        for element in list(blockquote):
+            if element.tag == "p" and _GITHUB_ALERT_REGEXP.match(element.text or ""):
+                blocks.append(blockquote.makeelement(blockquote.tag, blockquote.attrib))
+            if not blocks:
+                raise DocumentError(blockquote, "not a GitHub alert")
+            blockquote.remove(element)
+            blocks[-1].append(element)
+        return blocks
+
+    def _transform_github_alert_block(self, blockquote: ElementType) -> ElementType:
+        "Converts a single GitHub alert block-quote (as produced by `_split_github_alert_blocks`) into a Confluence panel or macro."
+
+        content = blockquote[0]
+        if content.text is None:
+            raise DocumentError(blockquote, "empty content for GitHub alert")
+
+        match = _GITHUB_ALERT_REGEXP.match(content.text)
+        if not match:
+            raise DocumentError(blockquote, "not a GitHub alert")
+        alert = match.group(1)
+
+        # remove alert indicator prefix
+        content.text = content.text[len(match.group(0)) :]
+
+        if self.options.use_panel:
+            return self._transform_panel(blockquote, alert.lower())
+        else:
+            class_name = _GITHUB_ALERT_TO_CSF.get(alert)
+            if class_name is None:
+                raise DocumentError(blockquote, f"unsupported GitHub alert: {alert}")
+
+            return self._transform_alert(blockquote, class_name)
+
     def _transform_github_alert(self, blockquote: ElementType) -> ElementType:
         """
         Creates a GitHub-style panel, normally triggered with a block-quote starting with a capitalized string such as `[!TIP]`.
@@ -1086,54 +1136,11 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
         if len(blockquote) < 1:
             raise DocumentError(blockquote, "empty GitHub alert")
 
-        pattern = re.compile(r"^\[!([A-Z]+)\]\s*")
-        alert_groups: list[tuple[str, list[ElementType]]] = []
-        for element in blockquote:
-            match = pattern.match(element.text or "") if element.tag == "p" else None
-            if match is not None:
-                alert_element = copy.deepcopy(element)
-                alert_element.text = alert_element.text[len(match.group(0)) :] if alert_element.text is not None else None
-                alert_groups.append((match.group(1), [alert_element]))
-            elif alert_groups:
-                alert_groups[-1][1].append(copy.deepcopy(element))
+        alert_blocks = self._split_github_alert_blocks(blockquote)
+        if len(alert_blocks) == 1:
+            return self._transform_github_alert_block(alert_blocks[0])
 
-        if len(alert_groups) > 1:
-            alert_elements: list[ElementType] = []
-            alert_to_csf = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
-            for alert, elements in alert_groups:
-                alert_block = copy.deepcopy(blockquote)
-                alert_block[:] = elements
-                if self.options.use_panel:
-                    alert_elements.append(self._transform_panel(alert_block, alert.lower()))
-                else:
-                    class_name = alert_to_csf.get(alert)
-                    if class_name is None:
-                        raise DocumentError(blockquote, f"unsupported GitHub alert: {alert}")
-                    alert_elements.append(self._transform_alert(alert_block, class_name))
-
-            return AC_ELEM("div", {}, *alert_elements)
-
-        content = blockquote[0]
-        if content.text is None:
-            raise DocumentError(blockquote, "empty content for GitHub alert")
-
-        match = pattern.match(content.text)
-        if not match:
-            raise DocumentError(blockquote, "not a GitHub alert")
-        alert = match.group(1)
-
-        # remove alert indicator prefix
-        content.text = content.text[len(match.group(0)) :]
-
-        if self.options.use_panel:
-            return self._transform_panel(blockquote, alert.lower())
-        else:
-            alert_to_csf = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
-            class_name = alert_to_csf.get(alert)
-            if class_name is None:
-                raise DocumentError(blockquote, f"unsupported GitHub alert: {alert}")
-
-            return self._transform_alert(blockquote, class_name)
+        return AC_ELEM("div", {}, *(self._transform_github_alert_block(alert_block) for alert_block in alert_blocks))
 
     def _transform_gitlab_alert(self, blockquote: ElementType) -> ElementType:
         """

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -465,6 +465,47 @@ _GITHUB_ALERT_REGEXP = re.compile(r"^\[!([A-Z]+)\]\s*")
 _GITHUB_ALERT_TO_CSF = {"NOTE": "info", "TIP": "tip", "IMPORTANT": "note", "WARNING": "note", "CAUTION": "warning"}
 
 
+def split_github_alert_groups(root: ElementType) -> None:
+    """
+    Splits a block-quote with several back-to-back `[!TYPE]` alerts into one block-quote per alert.
+
+    GitHub alerts written without a blank line between them (e.g. a `[!WARNING]` paragraph directly
+    followed by a `[!NOTE]` paragraph within the same block-quote) parse as a single block-quote with
+    multiple embedded paragraphs, each starting with its own `[!TYPE]` marker. This runs as a preprocessing
+    step on the raw parsed tree, before the tree visitor, so it can replace one such block-quote with
+    several sibling block-quotes -- one per alert -- moving each paragraph (and the non-alert content that
+    follows it) into its own block-quote. The tree visitor then sees the same structure it would see had
+    the alerts been written as genuinely separate block-quotes in the Markdown source, and produces
+    identical output for both cases.
+
+    :param root: Root of the parsed HTML element tree, mutated in place.
+    """
+
+    for blockquote in list(root.iter("blockquote")):
+        children = list(blockquote)
+        if not children or children[0].tag != "p" or not _GITHUB_ALERT_REGEXP.match(children[0].text or ""):
+            continue
+
+        group_count = sum(1 for e in children if e.tag == "p" and _GITHUB_ALERT_REGEXP.match(e.text or ""))
+        if group_count < 2:
+            continue
+
+        parent = blockquote.getparent()
+        if parent is None:
+            continue
+
+        groups: list[ElementType] = []
+        for element in children:
+            if element.tag == "p" and _GITHUB_ALERT_REGEXP.match(element.text or ""):
+                groups.append(blockquote.makeelement(blockquote.tag, blockquote.attrib))
+            blockquote.remove(element)
+            groups[-1].append(element)
+
+        index = parent.index(blockquote)
+        groups[-1].tail = blockquote.tail
+        parent[index : index + 1] = groups
+
+
 @dataclass(frozen=True)
 class ConfluencePanel:
     emoji: str
@@ -1077,32 +1118,19 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
                 AC_ELEM("rich-text-body", {}, *list(elem)),
             )
 
-    def _split_github_alert_blocks(self, blockquote: ElementType) -> list[ElementType]:
+    def _transform_github_alert(self, blockquote: ElementType) -> ElementType:
         """
-        Splits a block-quote with several back-to-back `[!TYPE]` alerts into one block-quote per alert.
+        Creates a GitHub-style panel, normally triggered with a block-quote starting with a capitalized string such as `[!TIP]`.
 
-        GitHub alerts written without a blank line between them (e.g. a `[!WARNING]` paragraph directly
-        followed by a `[!NOTE]` paragraph within the same block-quote) parse as a single block-quote with
-        multiple embedded paragraphs, each starting with its own `[!TYPE]` marker. This moves each such
-        paragraph (and the non-alert content that follows it) into its own block-quote, so the existing
-        single-alert logic can process each one independently.
-
-        :param blockquote: A `<blockquote>` element, possibly holding more than one `[!TYPE]`-tagged alert.
-        :returns: One block-quote per alert found; a single-element list when there is only one alert.
+        By the time this runs, `split_github_alert_groups` has already ensured `blockquote` holds a single
+        alert, even if the Markdown source had several `[!TYPE]` markers back-to-back in one block-quote.
         """
 
-        blocks: list[ElementType] = []
-        for element in list(blockquote):
-            if element.tag == "p" and _GITHUB_ALERT_REGEXP.match(element.text or ""):
-                blocks.append(blockquote.makeelement(blockquote.tag, blockquote.attrib))
-            if not blocks:
-                raise DocumentError(blockquote, "not a GitHub alert")
-            blockquote.remove(element)
-            blocks[-1].append(element)
-        return blocks
+        for e in blockquote:
+            self.visit(e)
 
-    def _transform_github_alert_block(self, blockquote: ElementType) -> ElementType:
-        "Converts a single GitHub alert block-quote (as produced by `_split_github_alert_blocks`) into a Confluence panel or macro."
+        if len(blockquote) < 1:
+            raise DocumentError(blockquote, "empty GitHub alert")
 
         content = blockquote[0]
         if content.text is None:
@@ -1124,23 +1152,6 @@ class ConfluenceStorageFormatConverter(NodeVisitor):
                 raise DocumentError(blockquote, f"unsupported GitHub alert: {alert}")
 
             return self._transform_alert(blockquote, class_name)
-
-    def _transform_github_alert(self, blockquote: ElementType) -> ElementType:
-        """
-        Creates a GitHub-style panel, normally triggered with a block-quote starting with a capitalized string such as `[!TIP]`.
-        """
-
-        for e in blockquote:
-            self.visit(e)
-
-        if len(blockquote) < 1:
-            raise DocumentError(blockquote, "empty GitHub alert")
-
-        alert_blocks = self._split_github_alert_blocks(blockquote)
-        if len(alert_blocks) == 1:
-            return self._transform_github_alert_block(alert_blocks[0])
-
-        return AC_ELEM("div", {}, *(self._transform_github_alert_block(alert_block) for alert_block in alert_blocks))
 
     def _transform_gitlab_alert(self, blockquote: ElementType) -> ElementType:
         """
@@ -1996,6 +2007,9 @@ class ConfluenceDocument:
             self.root = elements_from_strings(content)
         except ParseError as ex:
             raise ConversionError(f"failed to convert Markdown file: {path}") from ex
+
+        # normalize back-to-back GitHub alerts into separate block-quotes before the tree visitor runs
+        split_github_alert_groups(self.root)
 
         # configure HTML-to-Confluence converter
         converter_options = copy.deepcopy(self.options.converter)

--- a/tests/source/alert.md
+++ b/tests/source/alert.md
@@ -29,6 +29,16 @@ Caution:
 > [!CAUTION]
 > Advises about risks or negative outcomes of certain actions.
 
+Consecutive alerts, written back-to-back with no blank line between them:
+
+> [!WARNING]
+> Status: work in progress.
+>
+> This paragraph belongs to the warning.
+>
+> [!NOTE]
+> Source of truth: this page is generated from the source repo.
+
 ### GitLab
 
 Flag:

--- a/tests/target/alert.xml
+++ b/tests/target/alert.xml
@@ -35,6 +35,18 @@
     <p>Advises about risks or negative outcomes of certain actions.</p>
   </ac:rich-text-body>
 </ac:structured-macro>
+<p>Consecutive alerts, written back-to-back with no blank line between them:</p>
+<ac:structured-macro ac:name="note" ac:schema-version="1">
+  <ac:rich-text-body>
+    <p>Status: work in progress.</p>
+    <p>This paragraph belongs to the warning.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+<ac:structured-macro ac:name="info" ac:schema-version="1">
+  <ac:rich-text-body>
+    <p>Source of truth: this page is generated from the source repo.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
 <h3>GitLab</h3>
 <p>Flag:</p>
 <ac:structured-macro ac:name="note" ac:schema-version="1">

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from md2conf.attachment import attachment_name
 from md2conf.collection import ConfluencePageCollection, ConfluenceUserCollection
 from md2conf.compatibility import override
-from md2conf.converter import ConfluenceDocument, ConfluencePanel
+from md2conf.converter import ConfluenceDocument
 from md2conf.csf import canonicalize
 from md2conf.latex import LATEX_ENABLED
 from md2conf.matcher import Matcher, MatcherOptions
@@ -200,83 +200,6 @@ class TestConversion(TypedTestCase):
             expected = substitute(self.target_dir, f.read())
 
         self.assertEqual(actual, expected)
-
-    def test_github_adjacent_alerts_are_split(self) -> None:
-        content = """<!-- confluence-page-id: 123 -->
-# Test
-
-> [!WARNING]
-> Status: work in progress.
->
-> This paragraph belongs to the warning.
->
-> [!NOTE]
-> Source of truth: this page is generated from the source repo.
-"""
-
-        temp_path = self.source_dir / "github_alerts.md"
-        temp_path.write_text(content, encoding="utf-8")
-
-        warning_icon = ConfluencePanel.from_class["warning"].emoji_unicode
-        note_icon = ConfluencePanel.from_class["note"].emoji_unicode
-
-        try:
-            _, doc = ConfluenceDocument.create(
-                temp_path,
-                ProcessorOptions(converter=ConverterOptions(use_panel=True)),
-                self.source_dir,
-                self.site_metadata,
-                self.page_metadata,
-                self.user_metadata,
-            )
-            actual = doc.xhtml()
-            self.assertIn('ac:name="panel"', actual)
-            self.assertIn(f'panelIconId">{warning_icon}', actual)
-            self.assertIn(f'panelIconId">{note_icon}', actual)
-            self.assertIn("This paragraph belongs to the warning.", actual)
-            self.assertEqual(actual.count('ac:name="panel"'), 2)
-            self.assertNotIn("[!WARNING]", actual)
-            self.assertNotIn("[!NOTE]", actual)
-        finally:
-            temp_path.unlink(missing_ok=True)
-
-    def test_github_separate_alerts_are_unaffected(self) -> None:
-        "Two GitHub alerts as genuinely separate block-quotes (no continuous `>` streak) must keep working as before."
-
-        content = """<!-- confluence-page-id: 123 -->
-# Test
-
-> [!WARNING]
-> Status: work in progress.
-
-> [!NOTE]
-> Source of truth: this page is generated from the source repo.
-"""
-
-        temp_path = self.source_dir / "github_alerts_separate.md"
-        temp_path.write_text(content, encoding="utf-8")
-
-        warning_icon = ConfluencePanel.from_class["warning"].emoji_unicode
-        note_icon = ConfluencePanel.from_class["note"].emoji_unicode
-
-        try:
-            _, doc = ConfluenceDocument.create(
-                temp_path,
-                ProcessorOptions(converter=ConverterOptions(use_panel=True)),
-                self.source_dir,
-                self.site_metadata,
-                self.page_metadata,
-                self.user_metadata,
-            )
-            actual = doc.xhtml()
-            self.assertIn('ac:name="panel"', actual)
-            self.assertIn(f'panelIconId">{warning_icon}', actual)
-            self.assertIn(f'panelIconId">{note_icon}', actual)
-            self.assertEqual(actual.count('ac:name="panel"'), 2)
-            self.assertNotIn("[!WARNING]", actual)
-            self.assertNotIn("[!NOTE]", actual)
-        finally:
-            temp_path.unlink(missing_ok=True)
 
     def test_task_list_disabled(self) -> None:
         _, doc = ConfluenceDocument.create(

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -201,6 +201,42 @@ class TestConversion(TypedTestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_github_adjacent_alerts_are_split(self) -> None:
+        content = """<!-- confluence-page-id: 123 -->
+# Test
+
+> [!WARNING]
+> Status: work in progress.
+>
+> This paragraph belongs to the warning.
+>
+> [!NOTE]
+> Source of truth: this page is generated from the source repo.
+"""
+
+        temp_path = self.source_dir / "github_alerts.md"
+        temp_path.write_text(content, encoding="utf-8")
+
+        try:
+            _, doc = ConfluenceDocument.create(
+                temp_path,
+                ProcessorOptions(converter=ConverterOptions(use_panel=True)),
+                self.source_dir,
+                self.site_metadata,
+                self.page_metadata,
+                self.user_metadata,
+            )
+            actual = doc.xhtml()
+            self.assertIn('ac:name="panel"', actual)
+            self.assertIn('panelIconId">26a0-fe0f', actual)
+            self.assertIn('panelIconId">1f4dd', actual)
+            self.assertIn("This paragraph belongs to the warning.", actual)
+            self.assertEqual(actual.count('ac:name="panel"'), 2)
+            self.assertNotIn("[!WARNING]", actual)
+            self.assertNotIn("[!NOTE]", actual)
+        finally:
+            temp_path.unlink(missing_ok=True)
+
     def test_task_list_disabled(self) -> None:
         _, doc = ConfluenceDocument.create(
             self.source_dir / "tasklist.md",

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from md2conf.attachment import attachment_name
 from md2conf.collection import ConfluencePageCollection, ConfluenceUserCollection
 from md2conf.compatibility import override
-from md2conf.converter import ConfluenceDocument
+from md2conf.converter import ConfluenceDocument, ConfluencePanel
 from md2conf.csf import canonicalize
 from md2conf.latex import LATEX_ENABLED
 from md2conf.matcher import Matcher, MatcherOptions
@@ -217,6 +217,9 @@ class TestConversion(TypedTestCase):
         temp_path = self.source_dir / "github_alerts.md"
         temp_path.write_text(content, encoding="utf-8")
 
+        warning_icon = ConfluencePanel.from_class["warning"].emoji_unicode
+        note_icon = ConfluencePanel.from_class["note"].emoji_unicode
+
         try:
             _, doc = ConfluenceDocument.create(
                 temp_path,
@@ -228,9 +231,47 @@ class TestConversion(TypedTestCase):
             )
             actual = doc.xhtml()
             self.assertIn('ac:name="panel"', actual)
-            self.assertIn('panelIconId">26a0-fe0f', actual)
-            self.assertIn('panelIconId">1f4dd', actual)
+            self.assertIn(f'panelIconId">{warning_icon}', actual)
+            self.assertIn(f'panelIconId">{note_icon}', actual)
             self.assertIn("This paragraph belongs to the warning.", actual)
+            self.assertEqual(actual.count('ac:name="panel"'), 2)
+            self.assertNotIn("[!WARNING]", actual)
+            self.assertNotIn("[!NOTE]", actual)
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_github_separate_alerts_are_unaffected(self) -> None:
+        "Two GitHub alerts as genuinely separate block-quotes (no continuous `>` streak) must keep working as before."
+
+        content = """<!-- confluence-page-id: 123 -->
+# Test
+
+> [!WARNING]
+> Status: work in progress.
+
+> [!NOTE]
+> Source of truth: this page is generated from the source repo.
+"""
+
+        temp_path = self.source_dir / "github_alerts_separate.md"
+        temp_path.write_text(content, encoding="utf-8")
+
+        warning_icon = ConfluencePanel.from_class["warning"].emoji_unicode
+        note_icon = ConfluencePanel.from_class["note"].emoji_unicode
+
+        try:
+            _, doc = ConfluenceDocument.create(
+                temp_path,
+                ProcessorOptions(converter=ConverterOptions(use_panel=True)),
+                self.source_dir,
+                self.site_metadata,
+                self.page_metadata,
+                self.user_metadata,
+            )
+            actual = doc.xhtml()
+            self.assertIn('ac:name="panel"', actual)
+            self.assertIn(f'panelIconId">{warning_icon}', actual)
+            self.assertIn(f'panelIconId">{note_icon}', actual)
             self.assertEqual(actual.count('ac:name="panel"'), 2)
             self.assertNotIn("[!WARNING]", actual)
             self.assertNotIn("[!NOTE]", actual)


### PR DESCRIPTION
Two `[!TYPE]` alerts written back-to-back with no blank line between them parse as a single Markdown blockquote, so only the first alert was recognized -- the second one's `[!TYPE]` marker leaked into the page as literal text instead of rendering as its own panel. Split such a blockquote into one alert group per `[!TYPE]`-prefixed paragraph, and render each as its own panel or macro.

I would be another way, I guess, to fix #160

Fixes #160
