### PR TITLE
Synchronize an attachment once per page, not once per reference

### DIFF
--- a/md2conf/publisher.py
+++ b/md2conf/publisher.py
@@ -435,10 +435,16 @@ class SynchronizingProcessor(Processor):
         for attachment in self.api.get_attachments(page_id):
             attachments[attachment.title] = attachment.id
 
+        # attachment names synchronized in this pass; a document may reference the same image
+        # several times, and each reference must see the attachment ID the first one used
+        synchronized: set[str] = set()
+
         # update attachments with relative path
         base_path = path.parent
         for image_data in document.images:
             name = attachment_name(path_relative_to(image_data.path, base_path))
+            if name in synchronized:
+                continue
             self._synchronize_attachment(
                 page_id,
                 attachments.get(name),
@@ -446,10 +452,12 @@ class SynchronizingProcessor(Processor):
                 attachment_path=image_data.path,
                 comment=image_data.description,
             )
-            attachments.pop(name, None)
+            synchronized.add(name)
 
         # update attachments with embedded content
         for name, file_data in document.embedded_files.items():
+            if name in synchronized:
+                continue
             self._synchronize_attachment(
                 page_id,
                 attachments.get(name),
@@ -457,10 +465,12 @@ class SynchronizingProcessor(Processor):
                 raw_data=file_data.data,
                 comment=file_data.description,
             )
-            attachments.pop(name, None)
+            synchronized.add(name)
 
         # delete attachments no longer referenced
-        for attachment_id in attachments.values():
+        for name, attachment_id in attachments.items():
+            if name in synchronized:
+                continue
             self.api.delete_attachment(attachment_id)
 
         # synchronize page if page has any changes

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -167,6 +167,29 @@ class TestPublisher(unittest.TestCase):
             change_content=True,
         )
 
+    def test_synchronize_repeated_attachment_reference(self) -> None:
+        """Checks if an image shown several times on a page is uploaded only once."""
+
+        with MockConfluenceAPI() as api, _create_temporary_directory() as source_dir:
+            document_path = source_dir / "index.md"
+            attachment_path = source_dir / "diagram.png"
+            document_path.write_text(
+                "# Diagram\n\n" + "![diagram](diagram.png)\n\n" * 3,
+                encoding="utf-8",
+            )
+            attachment_path.write_bytes((Path(__file__).parent / "source" / "figure" / "raster.png").read_bytes())
+
+            publisher = Publisher(api, self.get_processor_options(api, keep_hierarchy=False, skip_update=True))
+            publisher.process_directory(source_dir)
+
+            page = api.get_page_properties_by_title("Diagram")
+            first_version = api.get_attachment_by_name(page.id, "diagram.png").version.number
+            self.assertEqual(first_version, 1)
+
+            publisher.process_directory(source_dir)
+            unchanged_version = api.get_attachment_by_name(page.id, "diagram.png").version.number
+            self.assertEqual(unchanged_version, first_version)
+
     def test_initialize_missing_attachment_checksum(self) -> None:
         """Checks if REST API v2 initializes a missing checksum with one upload."""
 


### PR DESCRIPTION
### The issue

A page that shows the same image more than once re-uploads it on every publish — once per extra reference — even when the file has not changed.

`AttachmentCatalog.images` is a list appended to per reference (`embedded_files` is a dict, so only images are affected). `_update_page` then removes each name from `attachments` after synchronizing it, to work out at the end which attachments are no longer referenced. So the second reference onwards reaches `_synchronize_attachment` with `attachments.get(name) is None`, and the checksum comparison there is guarded by `if attachment_id is not None` — it is skipped entirely, and the call falls through to `upload_attachment(..., force=True)`, whose `force` also bypasses the file-size check that would have stopped it.

The log for a page carrying one diagram four times, one of them twice, shows both halves of it:

```
INFO - _synchronize_attachment - Up-to-date attachment (matching checksum): assets_diagram.drawio
INFO - upload_attachment       - Uploading attachment:                      assets_diagram.drawio
```

Same file, same run: the checksum matched, and it was uploaded anyway.

### Why it is more than wasted versions

The upload lands on `/content/{page}/child/attachment/{id}/data`, the attachment **update** endpoint. We publish with per-author attribution — each page under the token of the person whose commit produced it — and a user who may edit the page is not necessarily allowed to update an attachment version created by someone else:

```
HTTPError: 403 Client Error: Forbidden for url:
  .../rest/api/content/<page>/child/attachment/<att>/data
PermissionException: You do not have permission to update this Attachment
```

md2conf raises, and the run dies partway through the tree — after some pages have been written to Confluence and before anything recorded that they were. For a single-token setup the same bug is invisible but still real: an attachment version per extra reference, per publish.

### The fix

Keep `attachments` intact as the ID lookup for the whole method, and track what was synchronized in a separate set that the delete-unreferenced pass reads instead. `continue` on an already-synchronized name also saves a content-property round trip per extra reference.

### Test

`tests/test_publisher.py::test_synchronize_repeated_attachment_reference` publishes a page that shows one image three times and asserts the attachment stays at version 1, then republishes and asserts it has not moved.

On `master` it fails on the first assertion — `AssertionError: 3 != 1`, three uploads on the very first publish. With the change, the full unit suite passes (132 tests), as do `ruff check` and `ruff format --check`.

Reproduced against `master` @ 9171b5a; 0.6.2 and 0.6.3 behave the same.