### PR TITLE
Allow a Confluence folder to act as a page parent

### DIFF
--- a/md2conf/api_v2.py
+++ b/md2conf/api_v2.py
@@ -6,6 +6,7 @@ Copyright 2022-2026, Levente Hunyadi
 :see: https://github.com/hunyadi/md2conf
 """
 
+import datetime
 import logging
 import typing
 from dataclasses import dataclass
@@ -251,8 +252,36 @@ class ConfluenceSessionV2(ConfluenceSessionShared):
 
     @override
     def get_page_properties(self, page_id: str) -> ConfluencePageProperties:
-        path = f"/pages/{page_id}"
-        return self._get(ConfluenceVersion.VERSION_2, path, ConfluencePageProperties)
+        try:
+            path = f"/pages/{page_id}"
+            return self._get(ConfluenceVersion.VERSION_2, path, ConfluencePageProperties)
+        except HTTPError as exc:
+            if exc.response is None or exc.response.status_code != 404:
+                raise
+            return self._get_folder_as_page_properties(page_id)
+
+    def _get_folder_as_page_properties(self, folder_id: str) -> ConfluencePageProperties:
+        """
+        Retrieves a Confluence folder through the page properties type, allowing a folder to act as a page parent.
+
+        Confluence Cloud places folders in the page hierarchy: pages report `parentType: "folder"`, and creating a
+        page accepts a folder ID as `parentId`. However, a folder is not a page, and `GET /pages/{id}` responds with
+        HTTP 404 for a folder ID.
+
+        :param folder_id: The Confluence folder ID.
+        :returns: Folder details in the shape of page properties.
+        """
+
+        path = f"/folders/{folder_id}"
+        data = self._get(ConfluenceVersion.VERSION_2, path, dict[str, JsonType])
+
+        # a folder reports `createdAt` as epoch milliseconds where a page uses an ISO-8601 string, and omits `lastOwnerId`
+        created = data.get("createdAt")
+        if isinstance(created, (int, float)):
+            data["createdAt"] = datetime.datetime.fromtimestamp(created / 1000, datetime.timezone.utc).isoformat()
+        data.setdefault("lastOwnerId", None)
+
+        return json_to_object(ConfluencePageProperties, data)
 
     @override
     def update_page(self, page_id: str, content: str, *, title: str, version: int, message: str) -> None:

--- a/tests/test_api_v2.py
+++ b/tests/test_api_v2.py
@@ -1,0 +1,113 @@
+"""
+Publish Markdown files to Confluence wiki.
+
+Copyright 2022-2026, Levente Hunyadi
+
+:see: https://github.com/hunyadi/md2conf
+"""
+
+import datetime
+import logging
+import unittest
+from typing import Any, TypeVar
+
+from requests import HTTPError, Response
+
+from md2conf.api_types import ConfluencePageProperties, ConfluenceVersion
+from md2conf.api_v2 import ConfluenceSessionV2
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(funcName)s [%(lineno)d] - %(message)s",
+)
+
+T = TypeVar("T")
+
+FOLDER_ID = "1234567890"
+
+# as returned by `GET /wiki/api/v2/folders/{id}`: no body, `createdAt` in epoch
+# milliseconds rather than ISO-8601, and no `lastOwnerId`
+FOLDER_PAYLOAD: dict[str, Any] = {
+    "id": FOLDER_ID,
+    "type": "folder",
+    "status": "current",
+    "title": "Planning",
+    "parentId": "1111111111",
+    "parentType": "page",
+    "position": 1781,
+    "authorId": "AUTHOR_ID",
+    "ownerId": "OWNER_ID",
+    "spaceId": "SPACE_ID",
+    "createdAt": 1785247544908,
+    "version": {"number": 1, "minorEdit": False},
+}
+
+
+def _http_error(status_code: int) -> HTTPError:
+    response = Response()
+    response.status_code = status_code
+    return HTTPError(f"{status_code} Client Error", response=response)
+
+
+class StubSession(ConfluenceSessionV2):
+    """
+    A session whose only behavior is a canned `_get`.
+
+    The base class constructor opens a connection to discover the site, which a unit test has no use for; this
+    double supplies the single method `get_page_properties` relies on, and records the paths it was asked for.
+    """
+
+    paths: list[str]
+    _pages_status: int
+
+    def __init__(self, *, pages_status: int) -> None:
+        self.paths = []
+        self._pages_status = pages_status
+
+    def _get(self, version: ConfluenceVersion, path: str, response_type: type[T], *, query: dict[str, str] | None = None) -> T:
+        self.paths.append(path)
+        if path.startswith("/pages/"):
+            raise _http_error(self._pages_status)
+        if path == f"/folders/{FOLDER_ID}":
+            return dict(FOLDER_PAYLOAD)  # type: ignore[return-value]
+        raise AssertionError(f"unexpected path: {path}")
+
+
+class ApiV2Test(unittest.TestCase):
+    def test_folder_is_returned_as_page_properties(self) -> None:
+        "A folder ID resolves through the folder endpoint, so a folder can act as a page parent."
+
+        session = StubSession(pages_status=404)
+        properties = session.get_page_properties(FOLDER_ID)
+
+        self.assertEqual(session.paths, [f"/pages/{FOLDER_ID}", f"/folders/{FOLDER_ID}"])
+        self.assertIsInstance(properties, ConfluencePageProperties)
+        self.assertEqual(properties.id, FOLDER_ID)
+        self.assertEqual(properties.title, "Planning")
+        self.assertEqual(properties.spaceId, "SPACE_ID")
+        self.assertEqual(properties.parentId, "1111111111")
+
+    def test_folder_timestamp_and_missing_owner_are_normalized(self) -> None:
+        "Epoch milliseconds become a datetime, and the absent `lastOwnerId` becomes None."
+
+        properties = StubSession(pages_status=404).get_page_properties(FOLDER_ID)
+
+        self.assertEqual(
+            properties.createdAt,
+            datetime.datetime.fromtimestamp(1785247544908 / 1000, datetime.timezone.utc),
+        )
+        self.assertIsNone(properties.lastOwnerId)
+
+    def test_error_other_than_not_found_is_raised(self) -> None:
+        "Only HTTP 404 means 'perhaps a folder'; anything else is a failure to report, not to retry elsewhere."
+
+        session = StubSession(pages_status=403)
+
+        with self.assertRaises(HTTPError):
+            session.get_page_properties(FOLDER_ID)
+
+        self.assertEqual(session.paths, [f"/pages/{FOLDER_ID}"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### The issue

Confluence Cloud places **folders** in the page hierarchy, and md2conf already models that: `ConfluencePageParentContentType.FOLDER` exists, and a page under a folder deserializes with `parentType: "folder"`.

But it is only ever *parsed*. Nothing can feed a folder in, because every path to a parent goes through `get_page_properties`, and `GET /pages/{id}` returns 404 for a folder ID:

```
404 .../api/v2/pages/1234567890
{"errors":[{"status":404,"code":"NOT_FOUND",
            "title":"Cannot find a page with id [1234567890]"}]}
```

Three call sites reach it, and each is fatal for a tree that contains a folder:

1. `SynchronizingProcessor._synchronize_subtree` — a directory node paired with a folder ID through front matter.
2. `ConfluenceSessionShared.get_or_create_page` — reads the parent only to learn its `spaceId`.
3. `ParentCatalog.is_traceable` — walks a page's ancestors, so it crosses any folder above the page.

The result is that publishing into a space that uses folders dies with an unhandled `HTTPError`. It is not "folders are unsupported" — a folder anywhere above a page makes that page unpublishable.

### The fix

`get_page_properties` falls back to `GET /folders/{id}`.

The fallback goes there rather than at the three call sites because it is the one place all three share, and `is_traceable` in particular walks IDs it never classifies — a narrower fix would have to teach that walk about folders. The cost is that a genuine "no such page" now pays one extra round-trip before it fails.

Two adjustments are needed for the folder payload to fit `ConfluencePageProperties`: `createdAt` is epoch milliseconds where a page uses an ISO-8601 string, and `lastOwnerId` is absent.

### How a folder gets into the tree

Pairing a directory with a folder makes sense together with `synchronized: false`, so md2conf establishes the hierarchy through the directory and never sends it content (a folder has no body):

```markdown
---
page_id: "1234567890"
synchronized: false
---
```

A caller who omits that flag fails loudly on `PUT /pages/{folderId}` rather than corrupting anything.

### Verified against a live instance

Beyond the unit tests, checked against a live Confluence Cloud instance on this branch:

- a new page under a folder-paired directory is created with `parentType: "folder"`;
- an already-bound page under a folder is updated and never re-parented;
- sibling reordering through the v1 move endpoint works with a folder as the parent;
- folders nested inside folders work;
- a `page_id` naming a folder that does not exist fails before anything is written;
- the folder's own version stays at 1 — no body is ever sent to it.

### Test

`tests/test_api_v2.py` covers the fallback without a live instance. `tests/api.py` substitutes the whole session, so `api_v2`'s HTTP layer is not reached by the existing suite — but `_get` is a single seam, and a session double with a canned `_get` is enough to assert that a 404 on `/pages/{id}` routes to `/folders/{id}`, that the folder's epoch-millisecond `createdAt` and absent `lastOwnerId` are normalized, and that any status other than 404 is raised rather than retried against the folder endpoint.

On `master` the first two fail with exactly the error this change is about:

```
requests.exceptions.HTTPError: 404 Client Error
FAILED (errors=2)
```

With the change, the full unit suite passes (135 tests), as do `ruff check`, `ruff format --check` and `mypy md2conf tests`.

Note for a follow-up rather than this PR: `MockConfluenceSession` hardcodes `parentType=ConfluencePageParentContentType.PAGE` and has no notion of folders, so publisher-level behaviour with a folder parent is still only covered by manual testing against a live instance. Glad to extend the mock if you would like that covered.

Reproduced against `master` @ 10a7def; 0.6.2 and 0.6.3 behave the same.
